### PR TITLE
Identify system-generated model entities

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "p-queue": "8.0.1",
         "radash": "12.1.0",
         "rehype-pretty-code": "0.14.0",
-        "ronin": "6.2.22",
+        "ronin": "6.2.24",
         "serialize-error": "11.0.3",
         "ua-parser-js": "1.0.39",
       },
@@ -291,13 +291,13 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.34.8", "", { "os": "win32", "cpu": "x64" }, "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g=="],
 
-    "@ronin/cli": ["@ronin/cli@0.2.39", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-r3yEBOCuVyTXOPouJKC/LWLByXE73TJo5bSFsYIDN04lKxBvCjrzGAfFJ8tMVdEeeBxz4slhoQkbWIxmysWuIQ=="],
+    "@ronin/cli": ["@ronin/cli@0.2.40", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.0.27", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-UTs0bCjO7vTYpCp9o9QJQrcP7X9vFQxl8nBBdHI786rgJLDbpMo0tUF3bwEFrQMCLx6J+VwsIW/Umn4EcMBzyw=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.17.11", "", {}, "sha512-6lPjWe8tHShsrAhVR1KnEKBgCf2YjC0WHjMu7TSsg0DmveSmUcFJbv9hdie2ERjcQFnq31xRzRQUESsFIEYAow=="],
+    "@ronin/compiler": ["@ronin/compiler@0.17.15", "", {}, "sha512-c6+s4VXNKsmogWy+WZYXc91q7usQFx3EEE5ow8jW1lK9yKDBlHXPQxWbkVS+FxYFcNOqbbI08QDUVN7WuyaiLQ=="],
 
     "@ronin/engine": ["@ronin/engine@0.0.27", "", { "dependencies": { "zod": "3.23.8" } }, "sha512-ArUFnfNH6pVZb3nQStDNZ2p2m4j9QXQTxPM+BrCB6mMYShXrEv9Ke4DiJb+js0IuVhydWWYyA1sql4Nf0IWY5Q=="],
 
-    "@ronin/syntax": ["@ronin/syntax@0.2.32", "", {}, "sha512-67jDmsdc3Lgf9zB1Zn2OvrjxGFRNL8P0NL0aok8tCLoZzgTVMKfAUwdZCy8992JRtK9AWxIcWLnUbAsxlHDjdw=="],
+    "@ronin/syntax": ["@ronin/syntax@0.2.33", "", {}, "sha512-YuGy4iMAyjsUpHpg1+4dVJvz9h8gxGnQtzdpfrKviuo64L+0pJmQHlLE848HWUeQaMfcP64TVA2stFHmOok2LQ=="],
 
     "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@8.30.0", "", { "dependencies": { "@sentry/core": "8.30.0", "@sentry/types": "8.30.0", "@sentry/utils": "8.30.0" } }, "sha512-pwX+awNWaxSOAsBLVLqc1+Hw+Fm1Nci9mbKFA6Ed5YzCG049PnBVQwugpmx2dcyyCqJpORhcIqb9jHdCkYmCiA=="],
 
@@ -853,7 +853,7 @@
 
     "rollup": ["rollup@4.34.8", "", { "dependencies": { "@types/estree": "1.0.6" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.34.8", "@rollup/rollup-android-arm64": "4.34.8", "@rollup/rollup-darwin-arm64": "4.34.8", "@rollup/rollup-darwin-x64": "4.34.8", "@rollup/rollup-freebsd-arm64": "4.34.8", "@rollup/rollup-freebsd-x64": "4.34.8", "@rollup/rollup-linux-arm-gnueabihf": "4.34.8", "@rollup/rollup-linux-arm-musleabihf": "4.34.8", "@rollup/rollup-linux-arm64-gnu": "4.34.8", "@rollup/rollup-linux-arm64-musl": "4.34.8", "@rollup/rollup-linux-loongarch64-gnu": "4.34.8", "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8", "@rollup/rollup-linux-riscv64-gnu": "4.34.8", "@rollup/rollup-linux-s390x-gnu": "4.34.8", "@rollup/rollup-linux-x64-gnu": "4.34.8", "@rollup/rollup-linux-x64-musl": "4.34.8", "@rollup/rollup-win32-arm64-msvc": "4.34.8", "@rollup/rollup-win32-ia32-msvc": "4.34.8", "@rollup/rollup-win32-x64-msvc": "4.34.8", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ=="],
 
-    "ronin": ["ronin@6.2.22", "", { "dependencies": { "@ronin/cli": "0.2.39", "@ronin/compiler": "0.17.11", "@ronin/syntax": "0.2.32" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-KrfThKn1egKqXdPKAI+4ao/Nj3KQa1y4rOfLjTbExQ8fnVF8ewA6ClDJT12mUu6xYoTfaNnobg2Hu8bDy86+9w=="],
+    "ronin": ["ronin@6.2.24", "", { "dependencies": { "@ronin/cli": "0.2.40", "@ronin/compiler": "0.17.15", "@ronin/syntax": "0.2.33" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-QiTdSNmS3x+BMZLeNT7R68gBq1Znt9Sgh+8kepbtPuzRK8KgNjpkiD8NvzZ22AVOq1DuA70Xj67lQXrq2p1L+g=="],
 
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "p-queue": "8.0.1",
     "radash": "12.1.0",
     "rehype-pretty-code": "0.14.0",
-    "ronin": "6.2.22",
+    "ronin": "6.2.24",
     "serialize-error": "11.0.3",
     "ua-parser-js": "1.0.39"
   },


### PR DESCRIPTION
This change ensures that model entities (fields, presets, etc.) that were automatically generated by RONIN are clearly marked as such, to prevent them from getting mixed up with the ones that were provided explicitly.

Originally, the change was landed in https://github.com/ronin-co/compiler/pull/157.