### PR TITLE
Adjust types for returning full queries from "before" hooks

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "p-queue": "8.0.1",
         "radash": "12.1.0",
         "rehype-pretty-code": "0.14.0",
-        "ronin": "6.2.27",
+        "ronin": "6.2.28",
         "serialize-error": "11.0.3",
         "ua-parser-js": "1.0.39",
       },
@@ -853,7 +853,7 @@
 
     "rollup": ["rollup@4.34.8", "", { "dependencies": { "@types/estree": "1.0.6" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.34.8", "@rollup/rollup-android-arm64": "4.34.8", "@rollup/rollup-darwin-arm64": "4.34.8", "@rollup/rollup-darwin-x64": "4.34.8", "@rollup/rollup-freebsd-arm64": "4.34.8", "@rollup/rollup-freebsd-x64": "4.34.8", "@rollup/rollup-linux-arm-gnueabihf": "4.34.8", "@rollup/rollup-linux-arm-musleabihf": "4.34.8", "@rollup/rollup-linux-arm64-gnu": "4.34.8", "@rollup/rollup-linux-arm64-musl": "4.34.8", "@rollup/rollup-linux-loongarch64-gnu": "4.34.8", "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8", "@rollup/rollup-linux-riscv64-gnu": "4.34.8", "@rollup/rollup-linux-s390x-gnu": "4.34.8", "@rollup/rollup-linux-x64-gnu": "4.34.8", "@rollup/rollup-linux-x64-musl": "4.34.8", "@rollup/rollup-win32-arm64-msvc": "4.34.8", "@rollup/rollup-win32-ia32-msvc": "4.34.8", "@rollup/rollup-win32-x64-msvc": "4.34.8", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ=="],
 
-    "ronin": ["ronin@6.2.27", "", { "dependencies": { "@ronin/cli": "0.2.40", "@ronin/compiler": "0.17.16", "@ronin/syntax": "0.2.35" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-ro3PHyN8mLMAs0e086brpUP7CvJCWzPDvP1P34ZmeVmYbfHM8Tu5CZaD66XJi6tI2lGRAReGMAPY+Hf62f3TJg=="],
+    "ronin": ["ronin@6.2.28", "", { "dependencies": { "@ronin/cli": "0.2.40", "@ronin/compiler": "0.17.16", "@ronin/syntax": "0.2.35" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-0WfY7gZ8iaqZ8CAIP+sFkoVbNb0QMWpmlQsPcJ0ugNQ5HE3+iI2itfofo6RYUxoDVDvAlL+UbZIYnCm1xDIKQw=="],
 
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "p-queue": "8.0.1",
     "radash": "12.1.0",
     "rehype-pretty-code": "0.14.0",
-    "ronin": "6.2.27",
+    "ronin": "6.2.28",
     "serialize-error": "11.0.3",
     "ua-parser-js": "1.0.39"
   },


### PR DESCRIPTION
In https://github.com/ronin-co/client/pull/83, we made it possible to return full queries (instead of just query instructions) from "before" data hooks.

The current change ensures that the types reflect this accordingly, which previously wasn't the case.

It also ensures that the types for `before*` hooks are applied correctly, which previously also wasn't the case.

Originally, the change was landed in https://github.com/ronin-co/client/pull/87.