### PR TITLE
Run "before" hooks for diff queries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "p-queue": "8.0.1",
         "radash": "12.1.0",
         "rehype-pretty-code": "0.14.0",
-        "ronin": "6.2.29",
+        "ronin": "6.2.30",
         "serialize-error": "11.0.3",
         "ua-parser-js": "1.0.39",
       },
@@ -853,7 +853,7 @@
 
     "rollup": ["rollup@4.34.9", "", { "dependencies": { "@types/estree": "1.0.6" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.34.9", "@rollup/rollup-android-arm64": "4.34.9", "@rollup/rollup-darwin-arm64": "4.34.9", "@rollup/rollup-darwin-x64": "4.34.9", "@rollup/rollup-freebsd-arm64": "4.34.9", "@rollup/rollup-freebsd-x64": "4.34.9", "@rollup/rollup-linux-arm-gnueabihf": "4.34.9", "@rollup/rollup-linux-arm-musleabihf": "4.34.9", "@rollup/rollup-linux-arm64-gnu": "4.34.9", "@rollup/rollup-linux-arm64-musl": "4.34.9", "@rollup/rollup-linux-loongarch64-gnu": "4.34.9", "@rollup/rollup-linux-powerpc64le-gnu": "4.34.9", "@rollup/rollup-linux-riscv64-gnu": "4.34.9", "@rollup/rollup-linux-s390x-gnu": "4.34.9", "@rollup/rollup-linux-x64-gnu": "4.34.9", "@rollup/rollup-linux-x64-musl": "4.34.9", "@rollup/rollup-win32-arm64-msvc": "4.34.9", "@rollup/rollup-win32-ia32-msvc": "4.34.9", "@rollup/rollup-win32-x64-msvc": "4.34.9", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-nF5XYqWWp9hx/LrpC8sZvvvmq0TeTjQgaZHYmAgwysT9nh8sWnZhBnM8ZyVbbJFIQBLwHDNoMqsBZBbUo4U8sQ=="],
 
-    "ronin": ["ronin@6.2.29", "", { "dependencies": { "@ronin/cli": "0.2.40", "@ronin/compiler": "0.17.16", "@ronin/syntax": "0.2.36" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-CjvDDq/yxxsnllDjupYrOKlmUgDtbVO/0Yxc6O5InUP3JtZxv/5t+TkmHtSQyAKbIFxzI332qOtv7V0iZLcxNw=="],
+    "ronin": ["ronin@6.2.30", "", { "dependencies": { "@ronin/cli": "0.2.40", "@ronin/compiler": "0.17.16", "@ronin/syntax": "0.2.36" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-VCizJUfIaGmtAxtM8Or5nGHx981I4QKgSL8r94pbTHDD0EN++tY3rNdoPH0w8c0zdTi+EhE7636htEVMu9KgMw=="],
 
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "p-queue": "8.0.1",
     "radash": "12.1.0",
     "rehype-pretty-code": "0.14.0",
-    "ronin": "6.2.29",
+    "ronin": "6.2.30",
     "serialize-error": "11.0.3",
     "ua-parser-js": "1.0.39"
   },


### PR DESCRIPTION
This change ensures that "before" hooks are run for automatically generated diff queries too.

We generate diff queries in order to provide data hooks with "before" and "after" results of mutations.

Originally, the change was landed in https://github.com/ronin-co/client/pull/89.