### PR TITLE
Allow multiple field segments in redirect

### DIFF
--- a/private/server/worker/tree.ts
+++ b/private/server/worker/tree.ts
@@ -525,7 +525,7 @@ const renderReactTree = async (
 
   // If the `href` (covers both `pathname` and `search` at once) of the page that should
   // be rendered contains field segments (represented as `{0.handle}`, for example), we
-  // want to replace those with the fields values contained in the results of the queries
+  // want to replace those with the field values contained in the results of the queries
   // that were run. For example, this allows for instructing BLADE to immediately provide
   // the destination page of a redirect directly instead of first rendering the original
   // page again and then redirecting.


### PR DESCRIPTION
The `useMutation` hook provides a `redirect` option that supports so-called "field segments".

If a field segment is located in the path of a redirect (e.g. `/{0.handle}`), it'll be replaced with the value of the field, taken from the results of the executed mutation queries.

The current change ensures that multiple field segments are supported per redirect.