### PR TITLE
Support default function exports

### DIFF
--- a/private/shell/loaders.ts
+++ b/private/shell/loaders.ts
@@ -42,6 +42,7 @@ export const getClientReferenceLoader: (
       contents += "const CLIENT_REFERENCE = Symbol.for('react.client.reference');\n";
       contents += "const REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref');\n";
 
+      contents = contents.replaceAll(/export default function/g, 'function');
       contents = contents.replaceAll(/export default (.*)/g, '');
       contents = contents.replaceAll(/export {([\s\S]*?)}/g, '');
       contents = contents.replaceAll(/export /g, '');

--- a/private/shell/utils.ts
+++ b/private/shell/utils.ts
@@ -101,7 +101,7 @@ export const scanExports = (transpiler: Transpiler, code: string): ExportItem[] 
     ? // Named default export — e.g. `export default Test;`
       code.match(/export default (\w+);/)?.[1] ||
       // Function default export — e.g. `export default function Graph() {}`
-      code.match(/export default function (\w+)\(\)/)?.[1]
+      code.match(/export default function (\w+)\(\) {/)?.[1]
     : null;
 
   return fileExports.map((name) => {


### PR DESCRIPTION
This change makes it possible to define client components as default function exports, such as:

```typescript
export default function Testing() {}
```

Previously, only `export default Testing;` has been supported.