### PR TITLE
Expose caching headers in production

### DIFF
--- a/private/shell/listener.ts
+++ b/private/shell/listener.ts
@@ -63,6 +63,13 @@ const requestHandler = await import(
   environment === 'development' ? serverInputFile : serverOutputFile
 );
 
+const assetHeaders: Record<string, string> =
+  environment === 'production'
+    ? {
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      }
+    : {};
+
 const server: Server = Bun.serve({
   port,
   development: environment === 'development',
@@ -92,11 +99,14 @@ const server: Server = Bun.serve({
         return new Response(newFileContents, {
           headers: {
             'Content-Type': outputFile.type,
+            ...assetHeaders,
           },
         });
       }
 
-      return new Response(outputFile);
+      return new Response(outputFile, {
+        headers: { ...assetHeaders },
+      });
     }
 
     if (publicFileExists) return new Response(publicFile);


### PR DESCRIPTION
This change ensures that the HTTP server provided by `blade serve` (used when Blade is run in stateful environments) returns headers for caching generated assets on the client and on proxy servers (CDNs).

Since the pathnames of the generated assets contain unique checksums, the caches are considered immutable.