### PR TITLE
Bundle React

### DIFF
--- a/private/server/components/root.tsx
+++ b/private/server/components/root.tsx
@@ -48,30 +48,6 @@ const Root = ({ children }: RootProps) => {
       suppressHydrationWarning={true}
       style={{ transitionProperty: 'none !important' }}>
       <head>
-        <script
-          type="importmap"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              imports: Object.fromEntries(
-                [
-                  'react',
-                  'react/jsx-runtime',
-                  'react/jsx-dev-runtime',
-                  'react-dom',
-                  'react-dom/client',
-                ].map((item) => {
-                  const [packageName, packagePath] = item.split('/');
-
-                  return [
-                    item,
-                    `https://esm.sh/${packageName}@0.0.0-experimental-df12d7eac-20230510/${packagePath || ''}`,
-                  ];
-                }),
-              ),
-            }),
-          }}
-        />
-
         {JSON.parse(import.meta.env.__BLADE_ASSETS).map(({ type, source }: Asset) => {
           switch (type) {
             case 'css':

--- a/private/shell/utils.ts
+++ b/private/shell/utils.ts
@@ -246,7 +246,6 @@ export const prepareClientAssets = async (environment: 'development' | 'producti
     target: 'browser',
     naming: path.basename(getOutputFile(bundleId, 'js')),
     minify: environment === 'production',
-    external: ['react', 'react-dom'],
     // On Cloudflare Pages, inline plain-text environment variables in the client bundles.
     define: Bun.env['CF_PAGES']
       ? Object.fromEntries(clientEnvironmentVariables)


### PR DESCRIPTION
Under version 1.2.5, we had to load `react` and `react-dom` from a CDN on the client-side, because of a bug in Bun.

The bug appears to be resolved now, which means we can start bundling those dependencies again.