### PR TITLE
Expose `list` query type

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
         "p-queue": "8.0.1",
         "radash": "12.1.0",
         "rehype-pretty-code": "0.14.0",
-        "ronin": "6.4.14",
+        "ronin": "6.4.15",
         "serialize-error": "11.0.3",
         "ua-parser-js": "1.0.39",
       },
@@ -853,7 +853,7 @@
 
     "rollup": ["rollup@4.38.0", "", { "dependencies": { "@types/estree": "1.0.7" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.38.0", "@rollup/rollup-android-arm64": "4.38.0", "@rollup/rollup-darwin-arm64": "4.38.0", "@rollup/rollup-darwin-x64": "4.38.0", "@rollup/rollup-freebsd-arm64": "4.38.0", "@rollup/rollup-freebsd-x64": "4.38.0", "@rollup/rollup-linux-arm-gnueabihf": "4.38.0", "@rollup/rollup-linux-arm-musleabihf": "4.38.0", "@rollup/rollup-linux-arm64-gnu": "4.38.0", "@rollup/rollup-linux-arm64-musl": "4.38.0", "@rollup/rollup-linux-loongarch64-gnu": "4.38.0", "@rollup/rollup-linux-powerpc64le-gnu": "4.38.0", "@rollup/rollup-linux-riscv64-gnu": "4.38.0", "@rollup/rollup-linux-riscv64-musl": "4.38.0", "@rollup/rollup-linux-s390x-gnu": "4.38.0", "@rollup/rollup-linux-x64-gnu": "4.38.0", "@rollup/rollup-linux-x64-musl": "4.38.0", "@rollup/rollup-win32-arm64-msvc": "4.38.0", "@rollup/rollup-win32-ia32-msvc": "4.38.0", "@rollup/rollup-win32-x64-msvc": "4.38.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-5SsIRtJy9bf1ErAOiFMFzl64Ex9X5V7bnJ+WlFMb+zmP459OSWCEG7b0ERZ+PEU7xPt4OG3RHbrp1LJlXxYTrw=="],
 
-    "ronin": ["ronin@6.4.14", "", { "dependencies": { "@ronin/cli": "0.3.3", "@ronin/compiler": "0.18.1", "@ronin/syntax": "0.2.37" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-GlkjRr2mFgyDjHYQzc4y4l74OStJIHdv/mg4Ol+2YBzhwAGt79buQI5DKkTaPUHkxW6UElpDHJ1Gj/4Y+pHxBQ=="],
+    "ronin": ["ronin@6.4.15", "", { "dependencies": { "@ronin/cli": "0.3.3", "@ronin/compiler": "0.18.1", "@ronin/syntax": "0.2.37" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-ks0YkM1fn1DLBTjXGBt4+YYINtAzxi3V+wfX8BMNH/n0/zkhkSp2AaRgq6AxsKv8RzI0PNAfMwCkC1xNSha6Qg=="],
 
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "p-queue": "8.0.1",
     "radash": "12.1.0",
     "rehype-pretty-code": "0.14.0",
-    "ronin": "6.4.14",
+    "ronin": "6.4.15",
     "serialize-error": "11.0.3",
     "ua-parser-js": "1.0.39"
   },

--- a/public/server/utils/data.ts
+++ b/public/server/utils/data.ts
@@ -7,15 +7,16 @@ import { getRoninOptions } from '../../../private/server/utils/data.ts';
 import { SERVER_CONTEXT } from '../../../private/server/worker/context.ts';
 import { prepareHooks } from '../../../private/server/worker/data-hooks';
 
-const { add, get, set, remove, count, batch } = initializeClient(() => {
-  const serverContext = SERVER_CONTEXT.getStore();
+const { add, get, set, remove, count, list, create, alter, drop, batch } =
+  initializeClient(() => {
+    const serverContext = SERVER_CONTEXT.getStore();
 
-  if (!serverContext) throw new Error('Missing server context for data hooks.');
+    if (!serverContext) throw new Error('Missing server context for data hooks.');
 
-  return getRoninOptions(
-    serverContext.requestContext,
-    prepareHooks(serverContext, hooks),
-  );
-});
+    return getRoninOptions(
+      serverContext.requestContext,
+      prepareHooks(serverContext, hooks),
+    );
+  });
 
-export { add, get, set, remove, count, batch };
+export { add, get, set, remove, count, list, create, alter, drop, batch };


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/blade/pull/42 and ensures that the TypeScript types for the `list` query type are being exported.