### PR TITLE
Add more `<meta>` elements

### DIFF
--- a/private/server/components/root.tsx
+++ b/private/server/components/root.tsx
@@ -15,6 +15,7 @@ const metadataNames: Record<string, string> = {
   'x.title': 'twitter:title',
   'x.description': 'twitter:description',
   'x.card': 'twitter:card',
+  'x.site': 'twitter:site',
   'x.creator': 'twitter:creator',
 
   'openGraph.title': 'og:title',

--- a/private/server/types/index.ts
+++ b/private/server/types/index.ts
@@ -49,6 +49,7 @@ export interface PageMetadata {
     title?: string;
     description?: string;
     card?: string;
+    site?: string;
     creator?: string;
     images?: string[];
   };


### PR DESCRIPTION
This change adds support for the following additional `meta` tag elements:

- `og:title`
- `og:description`
- `x:title`
- `x:description`
- `x:site`

Additionally, the `og:url` element now contains the full URL of the page, instead of only the protocol and host.

The meta tags are currently purposefully not derived from each other, as that will be added in a future iteration. For now, maximum control is necessary, since the services parsing those meta tags are often pretty fragile (e.g. the documentation X offers for their cards is pretty outdated).