### PR TITLE
Prefetch links on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,20 +327,20 @@ You may also decide to pass a TypeScript generic with the type of provided array
 usePaginationBuffer<ReactElement>();
 ```
 
-#### `useLinkOnClick` (Client)
+#### `useLinkEvents` (Client)
 
 In the majority of cases, you should use Blade's `<Link>` component to display links that should automatically result in a page transition (links pointing to external pages should just use anchor elements).
 
-In the rare scenario that you need to capture the `onClick` event of a link element yourself for other purposes, however, you can use `useLinkOnClick` to trigger the same `onClick` behavior that would normally be triggered for a `<Link>` component instance.
+In the rare scenario that you need to capture the `onMouseEnter` or `onMouseUp` event of a link element yourself for other purposes, however, you can use `useLinkEvents` to manually trigger the same event handlers that would normally be triggered for a `<Link>` component instance.
 
-For example, if a drag-and-drop system is used, it might want to overwrite the click handler and then choose to fire the user-provided one whenever it deems it to be a good idea, instead of the browser immediately firing it after the `onMouseUp` event.
+For example, if a drag-and-drop system is used, it might want to use those event handlers for different purposes (detecting whether an element is being dragged or dropped), so it could fire the ones provided by Blade at a different time.
 
 ```tsx
-import { useLinkOnClick } from '@ronin/blade/client/hooks';
+import { useLinkEvents } from '@ronin/blade/client/hooks';
 
-const onClick = useLinkOnClick('/pathname');
+const eventHandlers = useLinkEvents('/pathname');
 
-<button onClick={event => onClick(event)}>I am a link</button>
+<button {...eventHandlers}>I am a link</button>
 ```
 
 #### `use` (Server)

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ usePaginationBuffer<ReactElement>();
 
 In the majority of cases, you should use Blade's `<Link>` component to display links that should automatically result in a page transition (links pointing to external pages should just use anchor elements).
 
-In the rare scenario that you need to capture the `onMouseEnter` or `onMouseUp` event of a link element yourself for other purposes, however, you can use `useLinkEvents` to manually trigger the same event handlers that would normally be triggered for a `<Link>` component instance.
+In the rare scenario that you need to capture the click event of a link element yourself for other purposes, however, you can use `useLinkEvents` to manually trigger the same event handlers that would normally be triggered for a `<Link>` component instance.
 
 For example, if a drag-and-drop system is used, it might want to use those event handlers for different purposes (detecting whether an element is being dragged or dropped), so it could fire the ones provided by Blade at a different time.
 

--- a/private/client/components/history.client.tsx
+++ b/private/client/components/history.client.tsx
@@ -66,7 +66,7 @@ const HistoryContent = ({ children }: HistoryContentProps) => {
     const pageChanged = () => {
       const newLocation = window.location;
       const pathname = newLocation.pathname + newLocation.search + newLocation.hash;
-      transitionPage(pathname, 'manual');
+      transitionPage(pathname, 'manual')();
     };
 
     window.addEventListener('popstate', pageChanged);

--- a/private/client/hooks.ts
+++ b/private/client/hooks.ts
@@ -131,9 +131,10 @@ export const usePageTransition = () => {
     });
 
     return () => {
-      pagePromiseChain.then((defaultPage) => {
-        // At this point, the page is guaranteed to be available.
-        const page = defaultPage as FetchedPage;
+      pagePromiseChain.then((page) => {
+        // If the page is not available, then because the previous `.then()` call decided
+        // that it cannot be or should not be rendered.
+        if (!page) return;
 
         // The contents of this function are called immediately, and any state updates
         // performed within it will be marked as transitions.

--- a/private/client/utils/fetch-page.ts
+++ b/private/client/utils/fetch-page.ts
@@ -30,10 +30,15 @@ const loadResource = async (bundleId: string, type: 'style' | 'script') => {
   });
 };
 
+export interface FetchedPage {
+  body: ReactNode;
+  time: number;
+}
+
 const fetchPage = async (
   path: string,
   options?: PageFetchingOptions,
-): Promise<{ body: ReactNode; time: number } | null> => {
+): Promise<FetchedPage | null> => {
   let body = null;
 
   if (options && Object.keys(options).length > 0) {

--- a/public/client/components/link.client.tsx
+++ b/public/client/components/link.client.tsx
@@ -2,7 +2,7 @@ import { type AnchorHTMLAttributes, type ReactElement, cloneElement } from 'reac
 
 import { useUniversalContext } from '../../../private/universal/hooks';
 import { usePopulatePathname } from '../../universal/hooks';
-import { useLinkOnClick } from '../hooks';
+import { useLinkEvents } from '../hooks';
 
 interface LinkURL extends Omit<Partial<InstanceType<typeof URL>>, 'search'> {
   search?: string | Record<string, string | number | boolean | null>;
@@ -87,11 +87,11 @@ const Link = ({ href: hrefDefault, segments, children, ...extraProps }: LinkProp
 
   const populatePathname = usePopulatePathname();
   const destination = populatePathname(href, segments);
-  const onClick = useLinkOnClick(destination);
+  const linkEventHandlers = useLinkEvents(destination);
 
   return cloneElement(children, {
     href: destination,
-    onClick,
+    ...linkEventHandlers,
     ...extraProps,
   });
 };

--- a/public/client/hooks.ts
+++ b/public/client/hooks.ts
@@ -179,9 +179,9 @@ export const useMutation = () => {
 };
 
 // We're exposing this as a dedicated hook because there are often cases where it's not
-// possible to use our native `<Link>` component, but the event handler is still needed.
+// possible to use our native `<Link>` component, but the event handlers are still needed.
 // For example, if a drag-and-drop system is used, it might want to overwrite the click
-// handler and then choose to fire the user-provided one whenever it deems it to be a
+// handler and then choose to fire the one provided by Blade whenever it deems it to be a
 // good idea, instead of the browser immediately firing it after `onMouseUp`.
 export const useLinkEvents = (
   destination?: string,

--- a/public/client/hooks.ts
+++ b/public/client/hooks.ts
@@ -186,7 +186,7 @@ export const useLinkEvents = (
   destination?: string,
 ): {
   onMouseEnter: MouseEventHandler | undefined;
-  onMouseUp: MouseEventHandler | undefined;
+  onClick: MouseEventHandler | undefined;
 } => {
   const transitionPage = usePageTransition();
   const populatePathname = usePopulatePathname();
@@ -200,7 +200,7 @@ export const useLinkEvents = (
   if (!destination) {
     return {
       onMouseEnter: undefined,
-      onMouseUp: undefined,
+      onClick: undefined,
     };
   }
 
@@ -214,15 +214,8 @@ export const useLinkEvents = (
   };
 
   return {
-    onMouseEnter: (event: MouseEvent) => {
-      // With this, we're ensuring that the entire link acts like the default navigation
-      // behavior that normally applies when clicking a link. Meaning that, if a different
-      // event handler prevents the default action, we don't want to trigger the navigation.
-      if (event.defaultPrevented) return;
-
-      primePage();
-    },
-    onMouseUp: (event: MouseEvent) => {
+    onMouseEnter: () => primePage(),
+    onClick: (event: MouseEvent) => {
       // With this, we're ensuring that the entire link acts like the default navigation
       // behavior that normally applies when clicking a link. Meaning that, if a different
       // event handler prevents the default action, we don't want to trigger the navigation.

--- a/public/client/hooks.ts
+++ b/public/client/hooks.ts
@@ -224,8 +224,8 @@ export const useLinkEvents = (
 
     onClick: (event: MouseEvent) => {
       // With this, we're ensuring that the entire link acts like the default navigation
-      // behavior that normally applies when clicking a link. Meaning that, if a different
-      // event handler prevents the default action, we don't want to trigger the navigation.
+      // behavior that normally applies when clicking a link. Like that, if a different
+      // event handler prevents the default action, we don't want to trigger the link.
       if (event.defaultPrevented) return;
 
       // If someone wants to open the link in a new tab, we can just stop the execution of
@@ -237,11 +237,12 @@ export const useLinkEvents = (
       // Prevent the default browser behavior of links.
       event.preventDefault();
 
-      // In the majority of cases, `onMouseEnter` will fire before `onMouseUp` and prime
-      // the page cache. However, there are cases in which `onMouseEnter` does not fire
-      // before `onMouseUp`, such as when the element moves under a stationary pointer,
-      // for example via scrolling, CSS transforms, or DOM repositioning. In those cases,
-      // we have to make sure the page is still primed before we render it.
+      // In the majority of cases, `onClick` will fire after `onMouseUp` or
+      // `onTouchStart` and thereby prime the page cache. However, there are cases in
+      // which they don't fire before `onClick`, such as when the element moves under a
+      // stationary pointer, for example via scrolling, CSS transforms, or DOM
+      // repositioning. In those cases, we have to make sure the page is still primed
+      // before we can render it.
       if (!activeTransition.current) primePage();
 
       // Render the primed page.

--- a/public/client/hooks.ts
+++ b/public/client/hooks.ts
@@ -4,6 +4,7 @@ import { type SyntaxItem, getBatchProxy, getSyntaxProxy } from '@ronin/syntax/qu
 import {
   type MouseEvent,
   type MouseEventHandler,
+  type TouchEventHandler,
   useContext,
   useEffect,
   useRef,
@@ -185,8 +186,10 @@ export const useMutation = () => {
 export const useLinkEvents = (
   destination?: string,
 ): {
-  onMouseEnter: MouseEventHandler | undefined;
   onClick: MouseEventHandler | undefined;
+
+  onMouseEnter: MouseEventHandler | undefined;
+  onTouchStart: TouchEventHandler | undefined;
 } => {
   const transitionPage = usePageTransition();
   const populatePathname = usePopulatePathname();
@@ -199,8 +202,10 @@ export const useLinkEvents = (
   // elements does not allow `null`.
   if (!destination) {
     return {
-      onMouseEnter: undefined,
       onClick: undefined,
+
+      onMouseEnter: undefined,
+      onTouchStart: undefined,
     };
   }
 
@@ -215,6 +220,8 @@ export const useLinkEvents = (
 
   return {
     onMouseEnter: () => primePage(),
+    onTouchStart: () => primePage(),
+
     onClick: (event: MouseEvent) => {
       // With this, we're ensuring that the entire link acts like the default navigation
       // behavior that normally applies when clicking a link. Meaning that, if a different

--- a/public/universal/hooks.ts
+++ b/public/universal/hooks.ts
@@ -81,7 +81,7 @@ const useRedirect = () => {
 
     transitionPage(populatedPathname, 'manual', {
       immediatelyUpdateQueryParams: options?.immediatelyUpdateQueryParams,
-    });
+    })();
   };
 };
 


### PR DESCRIPTION
This change ensures that links are prefetched on hover (desktop) and touch start (mobile), which improved the performance of page transitions further.