### PR TITLE
Improve Tailwind CSS build error handling

### DIFF
--- a/private/shell/utils.ts
+++ b/private/shell/utils.ts
@@ -313,12 +313,12 @@ export const prepareClientAssets = async (environment: 'development' | 'producti
   );
   const tailwindProcessExitCode = await tailwindProcess.exited;
   if (tailwindProcessExitCode !== 0) {
-    clientSpinner.fail(`${loggingPrefixes.error} Failed to build Tailwind CSS styles.`);
+    clientSpinner.fail('Failed to build Tailwind CSS styles.');
     const { value } = await tailwindProcess.stderr.getReader().read();
     const errorMessage = new TextDecoder().decode(value);
     console.log(
       loggingPrefixes.error,
-      errorMessage.replaceAll('\n', `\n${loggingPrefixes.info}`),
+      errorMessage.replaceAll('\n', `\n${loggingPrefixes.error}`),
     );
     process.exit(1);
   }

--- a/private/shell/utils.ts
+++ b/private/shell/utils.ts
@@ -311,16 +311,18 @@ export const prepareClientAssets = async (environment: 'development' | 'producti
       cwd: process.cwd(),
     },
   );
-  const tailwindProcessExitCode = await tailwindProcess.exited;
-  if (tailwindProcessExitCode !== 0) {
-    clientSpinner.fail('Failed to build Tailwind CSS styles.');
-    const { value } = await tailwindProcess.stderr.getReader().read();
-    const errorMessage = new TextDecoder().decode(value);
-    console.log(
-      loggingPrefixes.error,
-      errorMessage.replaceAll('\n', `\n${loggingPrefixes.error}`),
-    );
-    process.exit(1);
+  if (environment === 'production') {
+    const tailwindProcessExitCode = await tailwindProcess.exited;
+    if (tailwindProcessExitCode !== 0) {
+      clientSpinner.fail('Failed to build Tailwind CSS styles.');
+      const { value } = await tailwindProcess.stderr.getReader().read();
+      const errorMessage = new TextDecoder().decode(value);
+      console.log(
+        loggingPrefixes.error,
+        errorMessage.replaceAll('\n', `\n${loggingPrefixes.error}`),
+      );
+      process.exit(1);
+    }
   }
 
   const fontFileDirectory = path.join(

--- a/private/shell/utils.ts
+++ b/private/shell/utils.ts
@@ -286,7 +286,7 @@ export const prepareClientAssets = async (environment: 'development' | 'producti
     'node_modules/.bin/tailwindcss',
   );
 
-  Bun.spawn(
+  const tailwindProcess = Bun.spawn(
     [
       tailwindBinPath,
       '--input',
@@ -311,6 +311,17 @@ export const prepareClientAssets = async (environment: 'development' | 'producti
       cwd: process.cwd(),
     },
   );
+  const tailwindProcessExitCode = await tailwindProcess.exited;
+  if (tailwindProcessExitCode !== 0) {
+    clientSpinner.fail(`${loggingPrefixes.error} Failed to build Tailwind CSS styles.`);
+    const { value } = await tailwindProcess.stderr.getReader().read();
+    const errorMessage = new TextDecoder().decode(value);
+    console.log(
+      loggingPrefixes.error,
+      errorMessage.replaceAll('\n', `\n${loggingPrefixes.info}`),
+    );
+    process.exit(1);
+  }
 
   const fontFileDirectory = path.join(
     path.dirname(require.resolve('@fontsource-variable/inter')),


### PR DESCRIPTION
This change updates how we handle using the Tailwind CSS CLI to bundle our CSS such that we actually handle errors returned by the CLI, rather than silently swallowing them.