### PR TITLE
Fix local dev server with `vercel dev`

### DIFF
--- a/private/shell/listener.ts
+++ b/private/shell/listener.ts
@@ -113,12 +113,7 @@ const server: Server = Bun.serve({
 
     if (publicFileExists) return new Response(publicFile);
 
-    const fetcher =
-      import.meta.env.__BLADE_PROVIDER === 'vercel'
-        ? requestHandler.default
-        : requestHandler.default.fetch;
-
-    return fetcher(request, {}, {});
+    return requestHandler.default.fetch(request, {}, {});
   },
   websocket:
     environment === 'development'


### PR DESCRIPTION
This changes fixes an issue introduced in #67 where a premature optimisation was made & seemed to actually break support of use of `vercel dev`.