### PR TITLE
Added `--port` support for examples

### DIFF
--- a/examples/advanced/bun.lock
+++ b/examples/advanced/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "advanced-example",
       "dependencies": {
-        "@ronin/blade": "0.3.6",
+        "@ronin/blade": "0.4.0",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
         "tailwindcss": "3.4.7",
@@ -34,7 +34,7 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@ronin/blade": ["@ronin/blade@0.3.6", "", { "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-Cegpiy2kuYwTZrRTiAu9qfxc5WIfJqPQdYyFl+TlsO0R2E20gZJrqHu5noS897ANQKCzpOWNnYckK/+Va1sf7g=="],
+    "@ronin/blade": ["@ronin/blade@0.4.0", "", { "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-73X6BM8xLJsuke3c4OfXeBpwRuZXVa4iqezD68T/VBj1K4cU30t+DGNrnYee9bFd4XJ6+tZGjpC++geTAJVF3Q=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 

--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -9,7 +9,7 @@
     },
     "author": "ronin",
     "dependencies": {
-        "@ronin/blade": "0.3.6",
+        "@ronin/blade": "0.4.0",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
         "tailwindcss": "3.4.7"

--- a/examples/basic/bun.lock
+++ b/examples/basic/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "basic-example",
       "dependencies": {
-        "@ronin/blade": "0.3.6",
+        "@ronin/blade": "0.4.0",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
         "tailwindcss": "3.4.7",
@@ -34,7 +34,7 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@ronin/blade": ["@ronin/blade@0.3.6", "", { "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-Cegpiy2kuYwTZrRTiAu9qfxc5WIfJqPQdYyFl+TlsO0R2E20gZJrqHu5noS897ANQKCzpOWNnYckK/+Va1sf7g=="],
+    "@ronin/blade": ["@ronin/blade@0.4.0", "", { "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-73X6BM8xLJsuke3c4OfXeBpwRuZXVa4iqezD68T/VBj1K4cU30t+DGNrnYee9bFd4XJ6+tZGjpC++geTAJVF3Q=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,7 +9,7 @@
   },
   "author": "ronin",
   "dependencies": {
-    "@ronin/blade": "0.3.6",
+    "@ronin/blade": "0.4.0",
     "react": "0.0.0-experimental-df12d7eac-20230510",
     "react-dom": "0.0.0-experimental-df12d7eac-20230510",
     "tailwindcss": "3.4.7"


### PR DESCRIPTION
This change introduces the feature added in https://github.com/ronin-co/blade/pull/89 to all Blade examples.