### PR TITLE
Rename `advanced` example's `hooks` to `triggers`

### DIFF
--- a/examples/advanced/bun.lock
+++ b/examples/advanced/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "advanced-example",
       "dependencies": {
-        "@ronin/blade": "0.4.0",
+        "@ronin/blade": "0.4.3",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
         "tailwindcss": "3.4.7",
@@ -34,7 +34,7 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@ronin/blade": ["@ronin/blade@0.4.0", "", { "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-73X6BM8xLJsuke3c4OfXeBpwRuZXVa4iqezD68T/VBj1K4cU30t+DGNrnYee9bFd4XJ6+tZGjpC++geTAJVF3Q=="],
+    "@ronin/blade": ["@ronin/blade@0.4.3", "", { "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-lClThRcl73s4kOPjXLCJx6gnoxwEYtOCmXUgy4FZpalY+QiRCCGtRJzPHfuZoBjP1isofvjiSJeK3OP9kP3HJw=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 

--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -9,7 +9,7 @@
     },
     "author": "ronin",
     "dependencies": {
-        "@ronin/blade": "0.4.0",
+        "@ronin/blade": "0.4.3",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
         "tailwindcss": "3.4.7"

--- a/examples/advanced/triggers/post.ts
+++ b/examples/advanced/triggers/post.ts
@@ -1,6 +1,9 @@
 import { MultipleWithInstructionsError } from '@ronin/blade/server/utils/errors';
 
-import type { AddTrigger, GetTrigger } from '@ronin/blade/universal/types';
+import type {
+  ResolvingAddTrigger,
+  ResolvingGetTrigger,
+} from '@ronin/blade/universal/types';
 
 interface Post {
   body: string;
@@ -30,7 +33,7 @@ const posts = [
   },
 ] satisfies Array<Post>;
 
-export const add: AddTrigger<Post> = (query, multiple) => {
+export const resolvingAdd: ResolvingAddTrigger<Post> = (query, multiple) => {
   if (multiple) throw new MultipleWithInstructionsError();
 
   const newPost = {
@@ -45,7 +48,10 @@ export const add: AddTrigger<Post> = (query, multiple) => {
   return newPost;
 };
 
-export const get: GetTrigger<Post | null | Array<Post>> = async (query, multiple) => {
+export const resolvingGet: ResolvingGetTrigger<Post | null | Array<Post>> = async (
+  query,
+  multiple,
+) => {
   if (multiple) return posts;
 
   return posts.find((post) => post.id === Number.parseInt(query.with?.id)) ?? null;

--- a/examples/basic/bun.lock
+++ b/examples/basic/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "basic-example",
       "dependencies": {
-        "@ronin/blade": "0.4.0",
+        "@ronin/blade": "0.4.3",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
         "tailwindcss": "3.4.7",
@@ -34,7 +34,7 @@
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
-    "@ronin/blade": ["@ronin/blade@0.4.0", "", { "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-73X6BM8xLJsuke3c4OfXeBpwRuZXVa4iqezD68T/VBj1K4cU30t+DGNrnYee9bFd4XJ6+tZGjpC++geTAJVF3Q=="],
+    "@ronin/blade": ["@ronin/blade@0.4.3", "", { "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-lClThRcl73s4kOPjXLCJx6gnoxwEYtOCmXUgy4FZpalY+QiRCCGtRJzPHfuZoBjP1isofvjiSJeK3OP9kP3HJw=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,7 +9,7 @@
   },
   "author": "ronin",
   "dependencies": {
-    "@ronin/blade": "0.4.0",
+    "@ronin/blade": "0.4.3",
     "react": "0.0.0-experimental-df12d7eac-20230510",
     "react-dom": "0.0.0-experimental-df12d7eac-20230510",
     "tailwindcss": "3.4.7"


### PR DESCRIPTION
This change fixes the `advanced` example from a recent change where `hooks` were renamed to `triggers`, as well as updating the name of the exports to use the `resolving` prefix.

Along with this, both examples have been upgraded to version `0.4.3`