### PR TITLE
Exclude JSON in Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.2/schema.json",
   "files": {
-    "include": ["./**/*.ts", "./**/*.tsx", "./**/*.json"],
+    "include": ["./**/*.ts", "./**/*.tsx"],
     "ignore": ["node_modules/", "bun.lockb", "tsconfig.json"]
   },
   "formatter": {


### PR DESCRIPTION
Since our release bot currently does not yet resume the format of `package.json`, we cannot let Biome format it.