### PR TITLE
Correctly handle Bun debug logs

### DIFF
--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -224,11 +224,11 @@ export const cleanUp = async () => {
  */
 export const handleBuildLogs = (output: BuildOutput) => {
   for (const log of output.logs) {
-    // Bun logs a warning when it encounters a `sideTriggers` property in `package.json`
+    // Bun logs a warning when it encounters a `sideEffects` property in `package.json`
     // containing a glob (a wildcard), because Bun doesn't support those yet. We want to
     // silence this warning, unless it is requested to be logged explicitly.
     if (
-      log.message.includes('wildcard sideTriggers') &&
+      log.message.includes('wildcard sideEffects') &&
       Bun.env['__BLADE_DEBUG_LEVEL'] !== 'verbose'
     )
       return;


### PR DESCRIPTION
This change ensures that Blade only prints these logs if `--debug` is passed as a flag:

![CleanShot 2025-05-16 at 11 13 17@2x](https://github.com/user-attachments/assets/fb96eb84-d878-4d07-bf78-19d041aa6248)

The change also removes the temporary `--queries` flag in favor of `--debug`.