### PR TITLE
Add support for custom Hono instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,8 +556,8 @@ In the rare case that you need to mount an API with a specific request signature
 ```typescript
 import { Hono } from "hono";
 
-const app = new Hono();
-app.post('/some-path', (c) => c.text('Testing'));
+const app = new Hono()
+  .post('/some-path', (c) => c.text('Testing'));
 
 export default app;
 ```

--- a/README.md
+++ b/README.md
@@ -537,6 +537,33 @@ useJWT<SessionToken>(token, secret);
 
 If the same JSON Web Token is parsed in different layouts surrounding a page or the page itself (this would happen if you place the hook in a shared utility hook in your app, for example), the token will only be parsed once and all instances of the hook will return its payload. In other words, JWTs are deduped across layouts and pages.
 
+### API Routes
+
+Blade automatically generates REST API routes at `/api` for your [triggers](https://ronin.co/docs/models/triggers) if you define the following in the file of your triggers:
+
+```typescript
+export const exposed = true;
+```
+
+API routes should only be used if you need to interact with your app from a client that is not the browser. For example, if you are also building a native iOS app, you could send HTTP requests to the auto-generated REST API.
+
+On the client-side of the application you've built using Blade (within the browser), however, you should always make use of [useMutation](#usemutation-client) instead, which guarantees that all read queries on the page are revalidated upon a mutation, avoiding the need for custom client-side data state management.
+
+#### Custom API Routes
+
+In the rare case that you need to mount an API with a specific request signature to your Blade application, you can add a `router.ts` file at the root of your application and place a [Hono](https://hono.dev) app inside of it, which will then be mounted by Blade:
+
+```typescript
+import { Hono } from "hono";
+
+const app = new Hono();
+app.post('/some-path', (c) => c.text('Testing'));
+
+export default app;
+```
+
+However, note that any paths mounted in this app cannot interface with the rest of your Blade application in any way. They are only meant to be used in edge cases where you cannot rely on Blade's [trigger](https://ronin.co/docs/models/triggers) feature.
+
 ### Revalidation (Stale-While-Revalidate, SWR)
 
 Blade intelligently keeps your data up-to-date for you, so no extra state management is needed for the output of your read queries. The data is refreshed:

--- a/README.md
+++ b/README.md
@@ -545,9 +545,9 @@ Blade automatically generates REST API routes at `/api` for your [triggers](http
 export const exposed = true;
 ```
 
-API routes should only be used if you need to interact with your app from a client that is not the browser. For example, if you are also building a native iOS app, you could send HTTP requests to the auto-generated REST API.
+API routes should only be used if you need to interact with your app from a client that is not the browser. For example, if you are also building a native iOS app, you could send HTTP requests to the auto-generated REST API from there.
 
-On the client-side of the application you've built using Blade (within the browser), however, you should always make use of [useMutation](#usemutation-client) instead, which guarantees that all read queries on the page are revalidated upon a mutation, avoiding the need for custom client-side data state management.
+On the client side of the application you've built using Blade (within the browser), however, you should always make use of [useMutation](#usemutation-client) instead, which guarantees that all read queries on the page are revalidated upon a mutation, avoiding the need for custom client-side data state management.
 
 #### Custom API Routes
 
@@ -562,7 +562,7 @@ app.post('/some-path', (c) => c.text('Testing'));
 export default app;
 ```
 
-However, note that any paths mounted in this app cannot interface with the rest of your Blade application in any way. They are only meant to be used in edge cases where you cannot rely on Blade's [trigger](https://ronin.co/docs/models/triggers) feature.
+However, note that paths mounted in this Hono app cannot interface with the rest of your Blade app in any way. They are only meant to be used in edge cases where you cannot rely on Blade's [trigger](https://ronin.co/docs/models/triggers) feature. In other words, your Hono app and your Blade app are two different apps running on the same server.
 
 ### Revalidation (Stale-While-Revalidate, SWR)
 

--- a/README.md
+++ b/README.md
@@ -562,7 +562,7 @@ app.post('/some-path', (c) => c.text('Testing'));
 export default app;
 ```
 
-However, note that paths mounted in this Hono app cannot interface with the rest of your Blade app in any way. They are only meant to be used in edge cases where you cannot rely on Blade's [trigger](https://ronin.co/docs/models/triggers) feature. In other words, your Hono app and your Blade app are two different apps running on the same server.
+However, note that paths mounted in this Hono app cannot interface with the rest of your Blade app in any way. They are only meant to be used in edge cases where you cannot rely on Blade's [trigger](https://ronin.co/docs/models/triggers) feature. In other words, your Hono app and your Blade app are two different apps running on the same domain.
 
 ### Revalidation (Stale-While-Revalidate, SWR)
 

--- a/private/server/types/global.d.ts
+++ b/private/server/types/global.d.ts
@@ -1,6 +1,7 @@
 declare module 'server-list' {
   export const pages: import('./index').PageList;
   export const triggers: import('./index').TriggersList;
+  export const router: import('hono').Hono | null;
 }
 
 declare module '@mapbox/timespace' {

--- a/private/server/worker/index.ts
+++ b/private/server/worker/index.ts
@@ -194,7 +194,7 @@ app.post('/api', async (c) => {
 });
 
 // If the application defines its own Hono instance, we need to mount it here.
-if (projectRouter) app.route('*', projectRouter);
+if (projectRouter) app.route('/', projectRouter);
 
 // Handle the initial render (first byte).
 app.get('*', (c) => {

--- a/private/server/worker/index.ts
+++ b/private/server/worker/index.ts
@@ -3,7 +3,7 @@ import { getCookie } from 'hono/cookie';
 import { Hono } from 'hono/tiny';
 import type { Query, QueryType } from 'ronin/types';
 import { InvalidResponseError } from 'ronin/utils';
-import { triggers as triggerList } from 'server-list';
+import { router as projectRouter, triggers as triggerList } from 'server-list';
 
 import { runQueries, toDashCase } from '@/private/server/utils/data';
 import {
@@ -192,6 +192,9 @@ app.post('/api', async (c) => {
   // Return the results of the provided queries.
   return c.json({ results });
 });
+
+// If the application defines its own Hono instance, we need to mount it here.
+if (projectRouter) app.route('*', projectRouter);
 
 // Handle the initial render (first byte).
 app.get('*', (c) => {

--- a/private/shell/constants.ts
+++ b/private/shell/constants.ts
@@ -19,6 +19,9 @@ export const outputDirectory = path.resolve(process.cwd(), '.blade');
 export const clientManifestFile = path.join(outputDirectory, 'client-manifest.json');
 export const serverOutputFile = path.join(outputDirectory, '_worker.js');
 
+// The path at which people can define a custom Hono app that Blade will mount.
+export const routerInputFile = path.join(process.cwd(), 'router.ts');
+
 export const styleInputFile = path.join(process.cwd(), 'styles.css');
 export const clientInputFile = require.resolve('./private/client/index.js');
 export const serverInputFile = require.resolve('./private/server/worker/index.js');

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -17,6 +17,7 @@ import {
   loggingPrefixes,
   outputDirectory,
   publicDirectory,
+  routerInputFile,
   styleInputFile,
 } from '@/private/shell/constants';
 import {
@@ -70,11 +71,17 @@ export const getFileList = async (): Promise<string> => {
   const directories = Object.entries(directoriesToParse);
   const importPromises = directories.map(([name, path]) => getImportList(name, path));
   const imports = await Promise.all(importPromises);
+  const routerExists = await exists(routerInputFile);
+
+  if (await exists(routerInputFile)) {
+    imports.push(`import { default as honoRouter } from '${routerInputFile}';`);
+  }
 
   let file = imports.join('\n\n');
 
   file += '\n\n';
-  file += 'export { pages, triggers };\n';
+  file += `const router = ${routerExists ? 'honoRouter' : 'null'};\n`;
+  file += 'export { pages, triggers, router };\n';
 
   return file;
 };


### PR DESCRIPTION
This change introduces support for adding a `router.ts` file at the root of the project, which can export a [Hono](https://hono.dev) instance, allowing for capturing arbitrary URL paths:

```typescript
import { Hono } from "hono";

const app = new Hono()
  .post('/some-path', (c) => c.text('Testing'));

export default app;
```