### PR TITLE
Use DOM library for TypeScript

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -28,7 +28,6 @@
         "@types/react": "18.3.6",
         "@types/react-dom": "18.3.0",
         "@types/ua-parser-js": "0.7.39",
-        "@types/web": "0.0.163",
         "@vercel/functions": "2.0.2",
         "@vitest/coverage-v8": "2.1.8",
         "async-retry": "1.3.3",
@@ -439,8 +438,6 @@
     "@types/ua-parser-js": ["@types/ua-parser-js@0.7.39", "", {}, "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "@types/web": ["@types/web@0.0.163", "", {}, "sha512-5Pg2gKfulo186wFnv+YXx0luJGWQ94cCY2/Dy8lU5WAE50FdBoOK45uBbp8FceOSpLJ4UW3dmTW5tvsN9uuX7A=="],
 
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
 

--- a/examples/advanced/tsconfig.json
+++ b/examples/advanced/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",

--- a/examples/basic/tsconfig.json
+++ b/examples/basic/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@types/react": "18.3.6",
     "@types/react-dom": "18.3.0",
     "@types/ua-parser-js": "0.7.39",
-    "@types/web": "0.0.163",
     "@vercel/functions": "2.0.2",
     "@vitest/coverage-v8": "2.1.8",
     "async-retry": "1.3.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Enable latest features
-    "lib": ["ESNext"],
+    "lib": ["ESNext", "DOM"],
     "target": "ESNext",
     "module": "ESNext",
     "moduleDetection": "force",


### PR DESCRIPTION
This change replaces the [@types/web](https://www.npmjs.com/package/@types/web) package with the `DOM` library in the TypeScript configuration.