### PR TITLE
Add Cloudflare Workers support

### DIFF
--- a/private/shell/builder.ts
+++ b/private/shell/builder.ts
@@ -20,6 +20,7 @@ import {
 } from '@/private/shell/utils';
 import {
   mapProviderInlineDefinitions,
+  transformToCloudflareOutput,
   transformToVercelBuildOutput,
 } from '@/private/shell/utils/providers';
 
@@ -52,6 +53,17 @@ if (output.success) {
   serverSpinner.fail();
 }
 
-if (provider === 'vercel') await transformToVercelBuildOutput();
+switch (provider) {
+  case 'cloudflare': {
+    await transformToCloudflareOutput();
+    break;
+  }
+  case 'vercel': {
+    await transformToVercelBuildOutput();
+    break;
+  }
+  default:
+    break;
+}
 
 handleBuildLogs(output);

--- a/private/shell/utils/providers.ts
+++ b/private/shell/utils/providers.ts
@@ -114,3 +114,16 @@ export const transformToVercelBuildOutput = async (): Promise<void> => {
 
   spinner.succeed();
 };
+
+/**
+ * Transform to match the Cloudflare output structure.
+ */
+export const transformToCloudflareOutput = async (): Promise<void> => {
+  const spinner = logSpinner(
+    'Transforming to output for Cloudflare (production)',
+  ).start();
+
+  await Bun.sleep(0);
+
+  spinner.succeed();
+};


### PR DESCRIPTION
This change updates the existing build system to include support for Cloudflare Workers + Assets, or Cloudflare Pages, as a deployment target.