### PR TITLE
Use peer dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@hono/sentry": "1.2.0",
         "@mapbox/timespace": "2.0.4",
         "@mdx-js/mdx": "3.0.1",
-        "@ronin/react": "0.1.2",
+        "@ronin/react": "0.1.3",
         "@sentry/bun": "8.55.0",
         "@sentry/react": "8.30.0",
         "@sentry/types": "8.30.0",
@@ -311,7 +311,7 @@
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 
-    "@ronin/react": ["@ronin/react@0.1.2", "", { "peerDependencies": { "react": ">=18.3.1", "ronin": ">=6.0.29" } }, "sha512-C0ULfvWzB6aYgdEriRIZUBgU4ERhVSeZBGk+RooN7R3omXcmv8KnjPl3kJkx7OUIrQk7oJhjleCt/GXKnKkbrg=="],
+    "@ronin/react": ["@ronin/react@0.1.3", "", { "peerDependencies": { "@ronin/compiler": ">=0.18.7", "react": ">=18.3.1", "ronin": ">=6.6.13" } }, "sha512-M84VWguyDLcpysP/unIbRomb2K7shfIuyxjaGseUIC/4ReqgZ18FV9HvsXyAqekpQKGB6tDBTVodJUbHMycPvA=="],
 
     "@ronin/syntax": ["@ronin/syntax@0.2.39", "", {}, "sha512-pNBbVYfuqwhxZ6/fIL46AjVoyGk8j8bjhY1TpQc86x7RIyDneujS/gZaaXfsI3bl8Ha2sFnkUEHqXkrv3ZVALg=="],
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@hono/sentry": "1.2.0",
     "@mapbox/timespace": "2.0.4",
     "@mdx-js/mdx": "3.0.1",
-    "@ronin/react": "0.1.2",
+    "@ronin/react": "0.1.3",
     "@sentry/bun": "8.55.0",
     "@sentry/react": "8.30.0",
     "@sentry/types": "8.30.0",


### PR DESCRIPTION
As it turns out, bundlers must know the unique origin of a piece of code (e.g. a function) in order to de-duplicate it.

For example, if two packages both bundle the same package x, then the code of package x will be duplicated in both of those packages.

Now, even if something imports those packages and runs a bundler, the code of package x will still be present twice, since the bundler is unable to know that both packages are using the same package x at the same version.

We therefore have two choices: Put all of our organization's code into a single monorepo (where deduping happens because all dependencies are known locally, which is not an option for us) or use peer dependencies (this is what we will do).

Originally, the change was landed in ronin-co/react-client#5.