### PR TITLE
Use peer dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
     "": {
       "name": "@ronin/blade",
       "dependencies": {
+        "@ronin/compiler": "0.18.7",
+        "@ronin/react": "0.1.3",
+        "@ronin/syntax": "0.2.40",
         "@tailwindcss/node": "4.1.6",
         "@tailwindcss/oxide": "4.1.6",
         "ronin": "6.6.13",
@@ -14,9 +17,6 @@
         "@hono/sentry": "1.2.0",
         "@mapbox/timespace": "2.0.4",
         "@mdx-js/mdx": "3.0.1",
-        "@ronin/compiler": "0.18.7",
-        "@ronin/react": "0.1.3",
-        "@ronin/syntax": "0.2.40",
         "@sentry/bun": "8.55.0",
         "@sentry/react": "8.30.0",
         "@sentry/types": "8.30.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,9 @@
   "author": "ronin",
   "license": "Apache-2.0",
   "dependencies": {
+    "@ronin/compiler": "0.18.7",
+    "@ronin/react": "0.1.3",
+    "@ronin/syntax": "0.2.40",
     "@tailwindcss/node": "4.1.6",
     "@tailwindcss/oxide": "4.1.6",
     "ronin": "6.6.13"
@@ -63,9 +66,6 @@
     "@hono/sentry": "1.2.0",
     "@mapbox/timespace": "2.0.4",
     "@mdx-js/mdx": "3.0.1",
-    "@ronin/compiler": "0.18.7",
-    "@ronin/react": "0.1.3",
-    "@ronin/syntax": "0.2.40",
     "@sentry/bun": "8.55.0",
     "@sentry/react": "8.30.0",
     "@sentry/types": "8.30.0",


### PR DESCRIPTION
As it turns out, bundlers must know the unique origin of a piece of code (e.g. a function) in order to de-duplicate it.

For example, if two packages both bundle the same package x, then the code of package x will be duplicated in both of those packages.

Now, even if something imports those packages and runs a bundler, the code of package x will still be present twice, since the bundler is unable to know that both packages are using the same package x at the same version.

We therefore have two choices: Put all of our organization's code into a single monorepo (where deduping happens because all dependencies are known locally, which is not an option for us) or use peer dependencies (this is what we will do).

Originally, the change was landed in https://github.com/ronin-co/syntax/pull/73.