### PR TITLE
Fix zero-config Cloudflare deployments

### DIFF
--- a/examples/basic/bun.lock
+++ b/examples/basic/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "basic-example",
       "dependencies": {
-        "@ronin/blade": "^0.7.12-ben-default-wrangler-config-experimental-427",
+        "@ronin/blade": "0.7.3",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
       },
@@ -63,17 +63,15 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
-    "@ronin/blade": ["@ronin/blade@0.7.12-ben-default-wrangler-config-experimental-427", "", { "dependencies": { "@ronin/compiler": "0.18.7", "@ronin/react": "0.1.3", "@ronin/syntax": "0.2.40", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "ronin": "6.6.13" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-L0O3lXmJlWa/LLiSbg0R4J9fQEny3/w0ZdGAIUHZwwcHsLFKoawSipx8iEbXs3f6v5NViNAokoU/RQKoKV5GBg=="],
+    "@ronin/blade": ["@ronin/blade@0.7.3", "", { "dependencies": { "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "ronin": "6.6.10" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-OBSm6ztAOJ1iGRgjJnI3CyXvcVHEf6plcWajm8MA6z+gTo0M+6MsFYWhaaUOfw4H3BUP7vwqQrynVEqr6rsvCA=="],
 
-    "@ronin/cli": ["@ronin/cli@0.3.16", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" }, "peerDependencies": { "@ronin/compiler": ">=0.18.6", "@ronin/engine": ">=0.1.23", "@ronin/syntax": ">=0.2.40" } }, "sha512-oqMfVeYaliPIwkmnGG4fgJFWGcW2nbFgajDerm6zi7JhcPHK0/GA9/+16gWrdVFRJFuFVeeL6zDtsey8G9IZkA=="],
+    "@ronin/cli": ["@ronin/cli@0.3.12", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "@ronin/engine": "0.1.23", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" } }, "sha512-2Fsn3NTMFu7GXoJO6GQv2+yK80Y3duUg8n/u7zJfQ3ND/DuEj6Xa2ycilmIMnzJ7NGkbRR52LI5+HcM4valTXA=="],
 
-    "@ronin/compiler": ["@ronin/compiler@0.18.7", "", { "peerDependencies": { "@ronin/engine": ">=0.1.23" } }, "sha512-2npAZw80sZ1sFM3oE6iuflCG8xrLT5NAe5WvkkCAX9MWiBJmnJ0Np0IthsH9SCx1pw6yWI+ksaojqFnHh9EEKg=="],
+    "@ronin/compiler": ["@ronin/compiler@0.18.5", "", {}, "sha512-RgWsaJHbAT92qRzLRbqwJiyyuK3rq8IadwIT3zc8+vVZV/P2SL8WLVNIt9+uaezfidRhLzZazzRSwwCTbFyLrA=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 
-    "@ronin/react": ["@ronin/react@0.1.3", "", { "peerDependencies": { "@ronin/compiler": ">=0.18.7", "react": ">=18.3.1", "ronin": ">=6.6.13" } }, "sha512-M84VWguyDLcpysP/unIbRomb2K7shfIuyxjaGseUIC/4ReqgZ18FV9HvsXyAqekpQKGB6tDBTVodJUbHMycPvA=="],
-
-    "@ronin/syntax": ["@ronin/syntax@0.2.40", "", { "peerDependencies": { "@ronin/compiler": ">=0.18.0" } }, "sha512-Uv6A4jBJrN0gZC3nSguUgUPmcdmriQjqSs9nFQlMJsVtFrFexPTUUDynWD+mR6cqqUBMR/ecQou19WR7yeEGpA=="],
+    "@ronin/syntax": ["@ronin/syntax@0.2.39", "", {}, "sha512-pNBbVYfuqwhxZ6/fIL46AjVoyGk8j8bjhY1TpQc86x7RIyDneujS/gZaaXfsI3bl8Ha2sFnkUEHqXkrv3ZVALg=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.1.6", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "enhanced-resolve": "^5.18.1", "jiti": "^2.4.2", "lightningcss": "1.29.2", "magic-string": "^0.30.17", "source-map-js": "^1.2.1", "tailwindcss": "4.1.6" } }, "sha512-ed6zQbgmKsjsVvodAS1q1Ld2BolEuxJOSyyNc+vhkjdmfNUDCmQnlXBfQkHrlzNmslxHsQU/bFmzcEbv4xXsLg=="],
 
@@ -233,7 +231,7 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
-    "ronin": ["ronin@6.6.13", "", { "dependencies": { "@ronin/cli": "0.3.16", "@ronin/compiler": "0.18.7", "@ronin/engine": "0.1.23", "@ronin/syntax": "0.2.40" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-CLpk4RvsOu0g0fKVpPnNo78e99PpsLnJqY71f9TYxaL3NLOm1ao0nte682tSI+s2wIGVzC/HVYflDMx0x9dTKg=="],
+    "ronin": ["ronin@6.6.10", "", { "dependencies": { "@ronin/cli": "0.3.12", "@ronin/compiler": "0.18.5", "@ronin/syntax": "0.2.39" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-cHZEfjkRj7ereotz/2RwxUY+kzMYO7bEW9kPyqjqL6w39qZCvqg8KQgHs/ZWIrwVhkyxmufLr26gub2KEy82CA=="],
 
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,7 +9,7 @@
   },
   "author": "ronin",
   "dependencies": {
-    "@ronin/blade": "^0.7.12-ben-default-wrangler-config-experimental-427",
+    "@ronin/blade": "0.7.3",
     "react": "0.0.0-experimental-df12d7eac-20230510",
     "react-dom": "0.0.0-experimental-df12d7eac-20230510"
   },


### PR DESCRIPTION
This change updates the Cloudflare transformer to check if any Wrangler configuration file exists and if none do exist, then we'll create a `wrangler.jsonc` file with the required bindings to deploy to Cloudflare Workers.

Additionally this fixes an oversight as part of #112 where the condition of `getProvider` only worked for Cloudflare Pages & not Cloudflare Workers.