### PR TITLE
Fix Cloudflare deployments default app token

### DIFF
--- a/examples/advanced/pages/about.tsx
+++ b/examples/advanced/pages/about.tsx
@@ -1,8 +1,0 @@
-const Page = () => (
-  <>
-    <h1>About me</h1>
-    <a href="/">Go back home</a>
-  </>
-);
-
-export default Page;

--- a/examples/advanced/pages/about.tsx
+++ b/examples/advanced/pages/about.tsx
@@ -1,0 +1,8 @@
+const Page = () => (
+  <>
+    <h1>About me</h1>
+    <a href="/">Go back home</a>
+  </>
+);
+
+export default Page;

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -159,6 +159,7 @@ export const setEnvironmentVariables = (options: {
   import.meta.env.__BLADE_PROVIDER = provider;
 
   if (provider === 'cloudflare') {
+    import.meta.env['BLADE_APP_TOKEN'] ??= '';
     import.meta.env['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['CF_PAGES_BRANCH'] ?? '';
     import.meta.env['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['CF_PAGES_COMMIT_SHA'] ?? '';
   }


### PR DESCRIPTION
This change fixes the `advanced` example's `/posts` page which is currently throwing an error when deployed to Cloudflare due to a `BLADE_APP_TOKEN` missing.