### PR TITLE
Ensure latest package version for examples

### DIFF
--- a/examples/advanced/bun.lock
+++ b/examples/advanced/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "advanced-example",
       "dependencies": {
-        "@ronin/blade": "0.7.13",
+        "@ronin/blade": "0.7.14",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
       },
@@ -63,7 +63,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
-    "@ronin/blade": ["@ronin/blade@0.7.13", "", { "dependencies": { "@ronin/compiler": "0.18.7", "@ronin/react": "0.1.3", "@ronin/syntax": "0.2.40", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "ronin": "6.6.13" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-U2tRiWp44wHe5oFL9FgWHbEspxX093RBhzHC0SpR7KDNhESQbMilN21WZS7O5Nkb3nba9krlRqOBgV99ZbLsng=="],
+    "@ronin/blade": ["@ronin/blade@0.7.14", "", { "dependencies": { "@ronin/compiler": "0.18.7", "@ronin/react": "0.1.3", "@ronin/syntax": "0.2.40", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "ronin": "6.6.13" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-1W5AoR+amSotDgMWmBvr2cIrr6S2a1fJemhlYMlE+U3CtH2MZX/1uuvP6UdvRYKphDTRyC9zqjfaYYbm9wc12A=="],
 
     "@ronin/cli": ["@ronin/cli@0.3.16", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" }, "peerDependencies": { "@ronin/compiler": ">=0.18.6", "@ronin/engine": ">=0.1.23", "@ronin/syntax": ">=0.2.40" } }, "sha512-oqMfVeYaliPIwkmnGG4fgJFWGcW2nbFgajDerm6zi7JhcPHK0/GA9/+16gWrdVFRJFuFVeeL6zDtsey8G9IZkA=="],
 

--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -9,7 +9,7 @@
   },
   "author": "ronin",
   "dependencies": {
-    "@ronin/blade": "0.7.13",
+    "@ronin/blade": "0.7.14",
     "react": "0.0.0-experimental-df12d7eac-20230510",
     "react-dom": "0.0.0-experimental-df12d7eac-20230510"
   },

--- a/examples/basic/bun.lock
+++ b/examples/basic/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "basic-example",
       "dependencies": {
-        "@ronin/blade": "0.7.13",
+        "@ronin/blade": "0.7.14",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
       },
@@ -63,7 +63,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
-    "@ronin/blade": ["@ronin/blade@0.7.13", "", { "dependencies": { "@ronin/compiler": "0.18.7", "@ronin/react": "0.1.3", "@ronin/syntax": "0.2.40", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "ronin": "6.6.13" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-U2tRiWp44wHe5oFL9FgWHbEspxX093RBhzHC0SpR7KDNhESQbMilN21WZS7O5Nkb3nba9krlRqOBgV99ZbLsng=="],
+    "@ronin/blade": ["@ronin/blade@0.7.14", "", { "dependencies": { "@ronin/compiler": "0.18.7", "@ronin/react": "0.1.3", "@ronin/syntax": "0.2.40", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "ronin": "6.6.13" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-1W5AoR+amSotDgMWmBvr2cIrr6S2a1fJemhlYMlE+U3CtH2MZX/1uuvP6UdvRYKphDTRyC9zqjfaYYbm9wc12A=="],
 
     "@ronin/cli": ["@ronin/cli@0.3.16", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" }, "peerDependencies": { "@ronin/compiler": ">=0.18.6", "@ronin/engine": ">=0.1.23", "@ronin/syntax": ">=0.2.40" } }, "sha512-oqMfVeYaliPIwkmnGG4fgJFWGcW2nbFgajDerm6zi7JhcPHK0/GA9/+16gWrdVFRJFuFVeeL6zDtsey8G9IZkA=="],
 

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,7 +9,7 @@
   },
   "author": "ronin",
   "dependencies": {
-    "@ronin/blade": "0.7.13",
+    "@ronin/blade": "0.7.14",
     "react": "0.0.0-experimental-df12d7eac-20230510",
     "react-dom": "0.0.0-experimental-df12d7eac-20230510"
   },


### PR DESCRIPTION
This change upgrades the version of `@ronin/blade` used by both the `advanced` & `basic` example to version `0.7.14`.