### PR TITLE
Hotreload when `.css` or `.env` files change

### DIFF
--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -162,7 +162,8 @@ if (isServing) {
       if (
         !filename?.includes('.client.') &&
         !filename?.endsWith('.mdx') &&
-        !filename?.endsWith('.css')
+        !filename?.endsWith('.css') &&
+        filename !== '.env'
       )
         return;
 
@@ -173,13 +174,11 @@ if (isServing) {
     for (const project of projects) {
       const pagePath = path.join(project, 'pages');
       const componentPath = path.join(project, 'components');
+      const cssPath = path.join(project, 'styles.css');
+      const envPath = path.join(project, '.env');
 
-      watch(project, { recursive: false }, (eventType, filename) => {
-        // Only consider CSS files that are not part of the hidden `.blade` directory.
-        if (filename?.endsWith('.css') && !filename.includes('.blade')) {
-          handleFileChange(eventType, filename);
-        }
-      });
+      watch(cssPath, {}, handleFileChange);
+      watch(envPath, {}, handleFileChange);
 
       watch(pagePath, { recursive: true }, handleFileChange);
 

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -158,14 +158,11 @@ if (isServing) {
     // resources unnecessarily.
     //
     // More details: https://linear.app/ronin/issue/RON-924
-    const handleFileChange: Parameters<typeof watch>[1] = async (eventType, filename) => {
-      if (!filename) return;
-
-      // Only process relevant file changes
+    const handleFileChange: Parameters<typeof watch>[1] = async (_, filename) => {
       if (
-        !filename.includes('.client.') &&
-        !filename.endsWith('.mdx') &&
-        !filename.endsWith('.css')
+        !filename?.includes('.client.') &&
+        !filename?.endsWith('.mdx') &&
+        !filename?.endsWith('.css')
       )
         return;
 


### PR DESCRIPTION
CSS and environment file changes now trigger hot reload in Blade.