### PR TITLE
Only watch files if they exist

### DIFF
--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -177,14 +177,14 @@ if (isServing) {
       const cssPath = path.join(project, 'styles.css');
       const envPath = path.join(project, '.env');
 
-      watch(cssPath, {}, handleFileChange);
-      watch(envPath, {}, handleFileChange);
-
       watch(pagePath, { recursive: true }, handleFileChange);
 
       if (await exists(componentPath)) {
         watch(componentPath, { recursive: true }, handleFileChange);
       }
+
+      if (await exists(cssPath)) watch(cssPath, {}, handleFileChange);
+      if (await exists(envPath)) watch(envPath, {}, handleFileChange);
     }
   }
 }


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/blade/pull/136 and prevents Blade from crashing if the files mentioned in the PR don't exist.