### PR TITLE
Add support for meta description

### DIFF
--- a/private/server/components/root.tsx
+++ b/private/server/components/root.tsx
@@ -150,14 +150,14 @@ const Root = ({ children, serverContext }: RootProps) => {
               );
 
             default: {
-              const tagName = metadataNames[name];
-              return tagName ? (
+              const tagName = metadataNames[name] || name;
+              return (
                 <meta
                   key={tagName + value}
                   name={tagName}
                   content={value as string}
                 />
-              ) : null;
+              );
             }
           }
         })}


### PR DESCRIPTION
This change ensures that the `description` field provided to `useMetadata` is correctly recognized.