### PR TITLE
Added remaining docs pages

### DIFF
--- a/docs/pages/api-routes.mdx
+++ b/docs/pages/api-routes.mdx
@@ -1,0 +1,30 @@
+---
+title: API Routes
+---
+
+# API Routes
+
+Blade automatically generates REST API routes at `/api` for your [triggers](https://ronin.co/docs/models/triggers) if you define the following in the file of your triggers:
+
+```typescript
+export const exposed = true;
+```
+
+API routes should only be used if you need to interact with your app from a client that is not the browser. For example, if you are also building a native iOS app, you could send HTTP requests to the auto-generated REST API from there.
+
+On the client side of the application you've built using Blade (within the browser), however, you should always make use of [useMutation](#usemutation-client) instead, which guarantees that all read queries on the page are revalidated upon a mutation, avoiding the need for custom client-side data state management.
+
+#### Custom API Routes
+
+In the rare case that you need to mount an API with a specific request signature to your Blade application, you can add a `router.ts` file at the root of your application and place a [Hono](https://hono.dev) app inside of it, which will then be mounted by Blade:
+
+```typescript
+import { Hono } from "hono";
+
+const app = new Hono()
+  .post('/some-path', (c) => c.text('Testing'));
+
+export default app;
+```
+
+However, note that paths mounted in this Hono app cannot interface with the rest of your Blade app in any way. They are only meant to be used in edge cases where you cannot rely on Blade's [trigger](https://ronin.co/docs/models/triggers) feature. In other words, your Hono app and your Blade app are two different apps running on the same domain.

--- a/docs/pages/client.mdx
+++ b/docs/pages/client.mdx
@@ -1,0 +1,114 @@
+---
+title: TypeScript Client
+---
+
+# TypeScript Client
+
+<div>
+
+By default, the `ronin` [package](https://www.npmjs.com/package/ronin) on npm does not require any configuration to function, which is partially due to the fact that the most important piece of configuration (the App Token) is loaded from the `RONIN_TOKEN` environment variable automatically:
+
+```ts
+import { get } from 'ronin';
+
+// No further config needed
+const posts = await get.posts();
+```
+
+In the case that `process.env.RONIN_TOKEN` is not available in the global variable scope, you will need to pass the App Token explicitly, like so:
+
+```ts
+import roninFactory from 'ronin';
+
+const ronin = roninFactory({
+  token: 'YOUR_APP_TOKEN',
+});
+
+const posts = await ronin.get.posts();
+```
+
+Certain frontend frameworks (like [Next.js](https://nextjs.org/)) will automatically provide `process.env`, regardless of whether the code is executed on the edge (”Edge Functions”) or in a runtime like Node.js (”Serverless Functions”), despite `process.env` being a Node.js primitive. This means you never need to pass the App Token manually when using Next.js.
+
+### Batching (Transactions)
+
+When running multiple write queries (`add`, `set`, or `remove`) at the same time, it is advised to batch them together as a transaction, which ensures that the respective database operations will be performed [atomically](<https://en.wikipedia.org/wiki/Atomicity_(database_systems)>).
+
+Specifically, if one of the queries fails to be applied for a certain reason, all of the other write queries will be reverted as well, so the data stored in RONIN is guaranteed to never get into a faulty state.
+
+```ts
+import { batch, add } from 'ronin';
+
+const [account, session] = await batch(() => [
+  set.account({
+    with: { id: '1234' },
+    to: { emailVerified: true },
+  }),
+  add.session.with({
+    account: { id: '1234' },
+  }),
+]);
+```
+
+In the example above, an “Account” record is first updated, after which a new “Session” record is created for it. The queries are executed in the order in which they are defined, and reverted (if an error occurs) in reverse order, meaning starting from the last.
+
+While database transactions are the designated use case for the exported `batch` method of the TypeScript client, you may also use it to ensure only a single query request is sent to RONIN, which might benefit the performance of your application:
+
+```ts
+import { batch, get } from 'ronin';
+
+const [account, session] = await batch(() => [
+  get.account.with.id('1234'),
+  get.session.with.account.id('1234'),
+]);
+```
+
+In the example above, the queries are still executed serially inside RONIN, but only a single outgoing network request is performed, meaning that RONIN is only invoked a single time.
+
+## Caching
+
+If you’re using [Next.js](https://nextjs.org/) or other frameworks that are caching outgoing `fetch` requests (which the RONIN JavaScript client uses internally), you can customize the behavior of `fetch` by passing custom options as config like so:
+
+```ts
+import roninFactory from 'ronin';
+
+const ronin = roninFactory({
+  fetch: { cache: 'force-cache' },
+});
+
+const ronin = roninFactory({
+  fetch: { next: { revalidate: 3600 } },
+});
+```
+
+Note that, for the `add`, `set`, and `remove` [query types](/docs/queries/types), the RONIN client specifies `cache: 'no-store'` by default, which skips the cache in Next.js, for example.
+
+## Config Factory
+
+To apply the same configuration for multiple different query invocations (which are called “scratchpads”), you can do so using a so-called “function factory”:
+
+```ts
+import roninFactory from 'ronin';
+
+const ronin = roninFactory({
+  token: 'YOUR_APP_TOKEN',
+});
+
+const posts = await ronin.get.posts();
+const reviews = await ronin.get.reviews();
+```
+
+If your environment requires you to pass the App Token configuration option explicitly, we strongly recommend initializing the `ronin` package only once and then passing around the initialized instance to keep your code as clean as possible.
+
+## Rendering Rich Text Fields
+
+Next to many other field types, RONIN also has a field type called the “Rich Text”.
+
+This field acts like an editor inside RONIN, allowing you to write long structured content such as product descriptions, blog posts, or even complete news articles.
+
+When saving the Rich Text field inside the RONIN dashboard, its contents are saved in a format called “Prosemirror JSON”.
+
+To render the field's contents inside your application, you can parse the format manually or use a library such as [tiptap/html](https://tiptap.dev/docs/editor/api/utilities/html) or [prosemirror-to-html-js](https://github.com/enVolt/prosemirror-to-html#prosemirror-to-html-js).
+
+A custom, more lightweight renderer crafted especially for content saved inside RONIN (which the docs you are reading are currently already using, as RONIN … uses RONIN) is being worked on.
+
+</div>

--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -67,6 +67,18 @@ const menuItems = [
     href: '/models/triggers',
     parentItem: 'models',
   },
+  {
+    id: 'types',
+    name: 'Types',
+    href: '/types',
+    parentItem: '',
+  },
+  {
+    id: 'client',
+    name: 'Client',
+    href: '/client',
+    parentItem: '',
+  },
 ];
 
 interface HeadingProps {

--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -68,6 +68,18 @@ const menuItems = [
     parentItem: 'models',
   },
   {
+    id: 'pages',
+    name: 'Pages',
+    href: '/pages',
+    parentItem: '',
+  },
+  {
+    id: 'api',
+    name: 'API Routes',
+    href: '/api-routes',
+    parentItem: '',
+  },
+  {
     id: 'types',
     name: 'Types',
     href: '/types',

--- a/docs/pages/pages.mdx
+++ b/docs/pages/pages.mdx
@@ -1,0 +1,18 @@
+---
+title: Pages
+---
+
+# Pages
+
+### Revalidation (Stale-While-Revalidate, SWR)
+
+Blade intelligently keeps your data up-to-date for you, so no extra state management is needed for the output of your read queries. The data is refreshed:
+
+- When a [mutation](#usemutation-client) happens (in the same DB transaction as the mutation).
+- Every 5 seconds while the window is in focus.
+- When the window gains focus.
+- When the device was offline and goes back online.
+
+Even the application itself is revalidated. Whenever you deploy a new version of your web app, Blade will detect the drift and synchronize itself between server and client, resolving the new client assets in the browser and replacing the UI with the updated code. This currently happens immediately, but will soon be limited to when the browser window is inactive.
+
+Lastly, even React iself is revalidated. If you upgrade React, Blade will unmount the old React on the client, mount the new React, and then re-mount your application.

--- a/docs/pages/types.mdx
+++ b/docs/pages/types.mdx
@@ -1,0 +1,68 @@
+---
+title: TypeScript Types
+---
+
+# TypeScript Types
+
+The `ronin` [package](https://www.npmjs.com/package/ronin) on npm provides the programmatic interface for querying RONIN.
+
+After defining your [database schema](/docs/models) in your repository, the `ronin` used within that same repository will automatically adapt its types to the schema you defined.
+
+However, if you have multiple repositories that interact with the same RONIN space, you may want to share the types between them. For all repositories that do not contain your database schema in code (there should only be one repository that contains it), RONIN offers an automatically generated types package that can be installed on those other repositories.
+
+## CLI
+
+To let the RONIN CLI initialize the types of your repository, first make sure you are logged in:
+
+```bash
+ronin login
+```
+
+Afterward, you can continue. The RONIN CLI automatically detects your package manager and configures your project’s `tsconfig.json` for you if you run the following command:
+
+```bash
+ronin types
+```
+
+And voilà! Now all the queries you run from the `ronin` TypeScript client will be typed automatically.
+
+## That’s it!
+
+Once you’ve completed the steps above, your queries will be auto-completed based on the schemas defined in your model definitions.
+
+Additionally, you may then also import the types and pass them around in your app:
+
+```ts
+import type { Post, Comments } from 'ronin';
+```
+
+## Updating Types
+
+Once you have updated one or more schemas, you can update the types like so:
+
+```bash
+ronin types
+```
+
+## CI / CD
+
+When running automated CI (Continuous Integration) systems such as [GitHub Actions](https://github.com/features/actions), you must provide a `.npmrc` file, which `npm` will load automatically.
+
+That’s also the file where `npm` places your credentials locally (usually, it can be found in your home directory, meaning `~/`).
+
+Locally, the file will contain a session token associated with your personal RONIN account, which allows you to install type packages for as many spaces as you want (depending on which spaces your account has access to on the dashboard).
+
+For CI, you can instead create a new App Token in the “Apps” section of your space and give it a name such as “GitHub Actions” (you may also include the name of your repository), after which you can add the following `.npmrc` file to your CI:
+
+```text "RONIN_TOKEN"#variable title=".npmrc"
+@ronin:registry=https://ronin.supply/
+//ronin.supply/:\_authToken=${RONIN_TOKEN}
+```
+
+The `RONIN_TOKEN` above would be the name of the environment variable that contains the token.
+
+## Vercel (Recommended)
+
+If you’re using Vercel, you only need to add the contents shown above to an environment variable named `NPM_RC`. Vercel will then [automatically provide](https://vercel.com/guides/using-private-dependencies-with-vercel) the config to `npm` for you.
+
+Also, don’t forget to add the `RONIN_TOKEN` environment variable, which allows the `ronin` package to access the data within your space.


### PR DESCRIPTION
This change adds the following pages to the docs site:

- "API Routes"
- "Pages"
- "Client"
- "Types"

The arrangement of the pages, their names and also contents will be refined further shortly.