### PR TITLE
Fix MDX hot-reloading

### DIFF
--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -194,8 +194,18 @@ if (isServing) {
       )
         return;
 
-      const file = Bun.file(path.join(pagesDirectory, 'index.tsx'));
-      await Bun.write(file, await file.text());
+      const indexTsx = path.join(pagesDirectory, 'index.tsx');
+      if (await exists(indexTsx)) {
+        const file = Bun.file(indexTsx);
+        await Bun.write(file, await file.text());
+        return;
+      }
+
+      const indexMdx = path.join(pagesDirectory, 'index.mdx');
+      if (await exists(indexMdx)) {
+        const file = Bun.file(indexMdx);
+        await Bun.write(file, await file.text());
+      }
     };
 
     for (const project of projects) {


### PR DESCRIPTION
This change updates the primary shell entrypoint's hot-reloading logic so it no longer throws an error if `pages/index.tsx` is not provided. The primary use case of which is if you are using a `pages/index.mdx` instead. Which this change also accounts for.