### PR TITLE
Fix docs "copy init to clipboard" logic

### DIFF
--- a/docs/components/copy-text.client.tsx
+++ b/docs/components/copy-text.client.tsx
@@ -1,13 +1,22 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { useState } from 'react';
 
-export const CopyText = ({ children }: { children: React.ReactNode }) => {
-  const [isCopied, setIsCopied] = useState(false);
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(children as string);
+import type { JSX } from 'react';
+
+export const CopyText = ({
+  children,
+  text,
+}: {
+  children: React.ReactNode;
+  text: string;
+}): JSX.Element => {
+  const [isCopied, setIsCopied] = useState<boolean>(false);
+
+  const handleCopy = (): void => {
+    navigator.clipboard.writeText(text);
     setIsCopied(true);
-    setTimeout(() => {
+    setTimeout((): void => {
       setIsCopied(false);
     }, 2000);
   };

--- a/docs/components/navbar.tsx
+++ b/docs/components/navbar.tsx
@@ -27,7 +27,7 @@ export const Navbar = () => {
           <div className="ml-auto flex items-center gap-2 md:flex-1 md:justify-end">
             <div className="flex items-center gap-0.5">
               <p className="font-mono text-xs">
-                <CopyText>
+                <CopyText text="bunx @ronin/blade init">
                   <span className="text-primary/80">$ bunx @ronin/blade init</span>
                 </CopyText>
               </p>


### PR DESCRIPTION
This change updates the `CopyText` component to add a new required `text` prop to use as the content to copy to the users clipboard, instead of trying to copy the JSX children, which currently just copies `[object Object]` to the clipboard.