### PR TITLE
Use correct title for Components page

### DIFF
--- a/docs/pages/components.mdx
+++ b/docs/pages/components.mdx
@@ -1,8 +1,8 @@
 ---
-title: Hooks
+title: Components
 ---
 
-# Hooks
+# Components
 
 ## `Link` (Client)
 


### PR DESCRIPTION
This change ensures a correct page title for the "Components" page!