### PR TITLE
Reduce documentation paragraph vertical margin

### DIFF
--- a/docs/components/code.tsx
+++ b/docs/components/code.tsx
@@ -12,7 +12,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
     <div className="relative">
       <pre
         {...restProps}
-        className="not-prose relative my-0! rounded-lg border p-5 text-sm">
+        className="not-prose relative my-0! rounded-lg border p-5 text-sm whitespace-pre-wrap">
         <code className="bg-none">{children}</code>
         <div className="absolute top-3 right-2">
           <CopyToClipboard content={children as string} />

--- a/docs/components/code.tsx
+++ b/docs/components/code.tsx
@@ -12,7 +12,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
     <div className="relative">
       <pre
         {...restProps}
-        className="not-prose relative my-0! rounded-lg border p-5 text-sm whitespace-pre-wrap">
+        className="not-prose relative my-0! whitespace-pre-wrap rounded-lg border p-5 text-sm">
         <code className="bg-none">{children}</code>
         <div className="absolute top-3 right-2">
           <CopyToClipboard content={children as string} />

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -25,7 +25,7 @@ html {
 	}
 
 	p {
-		@apply leading-relaxed [&:not(:first-child)]:mt-6 text-[#9E9E9E]
+		@apply leading-relaxed [&:not(:first-child)]:mt-1 text-[#9E9E9E]
 	}
 
 	code:not(pre code) {


### PR DESCRIPTION
This change reduces the margin between paragraphs in  our documentation.

Additionally this also fixes a bug with code snippets where the text was overflowing off the screen. Instead the text will now wrap to the next line.