### PR TITLE
All headings in docs now have anchor tags

### DIFF
--- a/docs/components/heading.client.tsx
+++ b/docs/components/heading.client.tsx
@@ -4,7 +4,7 @@ import type { JSX } from 'react';
 
 interface HeadingProps {
   children: React.ReactNode;
-  level: number;
+  level: 1 | 2 | 3 | 4 | 5 | 6;
 }
 
 export const Heading = ({ children, level, ...props }: HeadingProps) => {

--- a/docs/components/heading.client.tsx
+++ b/docs/components/heading.client.tsx
@@ -1,11 +1,15 @@
 import { Button } from '@/components/ui/button';
 import { LinkIcon } from 'lucide-react';
+import type { JSX } from 'react';
 
 interface HeadingProps {
   children: React.ReactNode;
+  level: number;
 }
 
-export const Heading = ({ children, ...props }: HeadingProps) => {
+export const Heading = ({ children, level, ...props }: HeadingProps) => {
+  const HeadingComponent = `h${level}` as keyof JSX.IntrinsicElements;
+
   return (
     <a
       data-heading={true}
@@ -23,7 +27,7 @@ export const Heading = ({ children, ...props }: HeadingProps) => {
           height={12}
         />
       </Button>
-      <h1 {...props}>{children}</h1>
+      <HeadingComponent {...props}>{children}</HeadingComponent>
     </a>
   );
 };

--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -159,6 +159,12 @@ export const components = {
       {...props}
     />
   ),
+  h6: (props: HeadingProps) => (
+    <Heading
+      level={6}
+      {...props}
+    />
+  ),
 };
 
 export default DocsLayout;

--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -129,7 +129,36 @@ const DocsLayout = ({
 // biome-ignore lint/nursery/useComponentExportOnlyModules: This is needed for the docs.
 export const components = {
   pre: (props: CodeProps) => <Code {...props} />,
-  h1: (props: HeadingProps) => <Heading {...props} />,
+  h1: (props: HeadingProps) => (
+    <Heading
+      level={1}
+      {...props}
+    />
+  ),
+  h2: (props: HeadingProps) => (
+    <Heading
+      level={2}
+      {...props}
+    />
+  ),
+  h3: (props: HeadingProps) => (
+    <Heading
+      level={3}
+      {...props}
+    />
+  ),
+  h4: (props: HeadingProps) => (
+    <Heading
+      level={4}
+      {...props}
+    />
+  ),
+  h5: (props: HeadingProps) => (
+    <Heading
+      level={5}
+      {...props}
+    />
+  ),
 };
 
 export default DocsLayout;


### PR DESCRIPTION
Previously, only the h1 element was replaced with our custom heading. Now, all heading elements have been updated to include support for an anchor tag, allowing users to copy the URL to the clipboard.