### PR TITLE
Make `useCookie` work on the client

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -57,7 +57,8 @@
         "useExplicitType": "off",
         "useGuardForIn": "off",
         "noHeadElement": "off",
-        "noExportedImports": "off"
+        "noExportedImports": "off",
+        "noDocumentCookie": "off"
       },
       "performance": {
         "all": true,

--- a/docs/pages/hooks.mdx
+++ b/docs/pages/hooks.mdx
@@ -371,12 +371,12 @@ To count records, the `useCountOf` hook can be used with the same syntax as the 
 
 If the same read query is used in different layouts surrounding a page or the page itself (this would happen if you place the hook in a shared utility hook in your app, for example), the query will only be run once and all instances of the hook will return its results. In other words, queries are deduped across layouts and pages.
 
-## `useCookie` (Server)
+## `useCookie`
 
 Allows for reading and writing cookies on the server. The cookies are attached to the headers of the resulting HTTP request before the JSX stream of React elements begins.
 
 ```tsx
-import { useCookie } from '@ronin/blade/server/hooks';
+import { useCookie } from '@ronin/blade/hooks';
 
 const Page = () => {
     const [tokenCookie, setTokenCookie] = useCookie('token');

--- a/docs/pages/hooks.mdx
+++ b/docs/pages/hooks.mdx
@@ -6,36 +6,36 @@ title: Hooks
 
 Blade provides the following React hooks:
 
-## `useLocation` (Universal)
+## `useLocation`
 
 Mimics [document.location](https://developer.mozilla.org/en-US/docs/Web/API/Document/location) and thereby exposes a `URL` object containing the URL of the current page.
 
 Unlike in `document.location`, however, the URL is not populated, so dynamic path segments of pages will not be populated with their respective value.
 
 ```tsx
-import { useLocation } from '@ronin/blade/universal/hooks';
+import { useLocation } from '@ronin/blade/hooks';
 
 const location = useLocation();
 ```
 
-## `useParams` (Universal)
+## `useParams`
 
 Exposes the keys and values of all parameters (dynamic path segments) present in the URL.
 
 For example, if the URL being accessed is `/elaine` and the page is named `[handle].tsx`, the returned object would be `{ handle: 'elaine' }`.
 
 ```tsx
-import { useParams } from '@ronin/blade/universal/hooks';
+import { useParams } from '@ronin/blade/hooks';
 
 const params = useParams();
 ```
 
-## `useRedirect` (Universal)
+## `useRedirect`
 
 Used to transition to a different page.
 
 ```tsx
-import { useRedirect } from '@ronin/blade/universal/hooks';
+import { useRedirect } from '@ronin/blade/hooks';
 
 const redirect = useRedirect();
 
@@ -59,14 +59,14 @@ redirect('/pathname', {
 });
 ```
 
-## `usePopulatePathname` (Universal)
+## `usePopulatePathname`
 
 As mentioned in the docs for `useLocation()`, dynamic path segments (such as `/[handle]`) are not populated in the `URL` object exposed by the hook.
 
 To populate them, you can pass the pathname to the `usePopulatePathname()` hook.
 
 ```tsx
-import { usePopulatePathname } from '@ronin/blade/universal/hooks';
+import { usePopulatePathname } from '@ronin/blade/hooks';
 
 const populatePathname = usePopulatePathname();
 
@@ -86,12 +86,12 @@ populatePathname('/[handle]', {
 });
 ```
 
-## `useNavigator` (Universal)
+## `useNavigator`
 
 Mimics [window.navigator](https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator) and thereby exposes an object containing details about the current user agent.
 
 ```tsx
-import { useNavigator } from '@ronin/blade/universal/hooks';
+import { useNavigator } from '@ronin/blade/hooks';
 
 const navigator = useNavigator();
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "exports": {
     "./client/": "./dist/public/client/",
     "./server/": "./dist/public/server/",
-    "./hooks": "./dist/public/universal/hooks",
-    "./schema": "./dist/public/universal/schema",
-    "./types": "./dist/public/universal/types"
+    "./hooks": "./dist/public/universal/hooks.js",
+    "./schema": "./dist/public/universal/schema.js",
+    "./types": "./dist/public/universal/types.js"
   },
   "typesVersions": {
     "*": {

--- a/package.json
+++ b/package.json
@@ -25,24 +25,28 @@
     "prepare": "bun run build"
   },
   "exports": {
-    ".": "./dist/public/universal/",
     "./client/": "./dist/public/client/",
     "./server/": "./dist/public/server/",
-    "./schema": "./dist/public/universal/schema"
+    "./hooks": "./dist/public/universal/hooks",
+    "./schema": "./dist/public/universal/schema",
+    "./types": "./dist/public/universal/types"
   },
   "typesVersions": {
     "*": {
-      "*": [
-        "./dist/public/universal/*"
-      ],
       "client/*": [
         "./dist/public/client/*"
       ],
       "server/*": [
         "./dist/public/server/*"
       ],
+      "hooks": [
+        "./dist/public/universal/hooks"
+      ],
       "schema": [
         "./dist/public/universal/schema"
+      ],
+      "types": [
+        "./dist/public/universal/types"
       ]
     }
   },

--- a/public/universal/hooks.ts
+++ b/public/universal/hooks.ts
@@ -1,11 +1,11 @@
 import type { CookieSerializeOptions } from 'cookie';
+import { useContext } from 'react';
 
 import { type RootTransitionOptions, usePageTransition } from '@/private/client/hooks';
 import { RootServerContext } from '@/private/server/context';
 import { usePrivateLocation, useUniversalContext } from '@/private/universal/hooks';
 import type { CustomNavigator } from '@/private/universal/types/util';
 import { populatePathSegments } from '@/private/universal/utils/paths';
-import { useContext } from 'react';
 
 const useParams = <
   TParams extends Record<string, unknown> | Array<string> = Record<

--- a/public/universal/hooks.ts
+++ b/public/universal/hooks.ts
@@ -1,7 +1,11 @@
+import type { CookieSerializeOptions } from 'cookie';
+
 import { type RootTransitionOptions, usePageTransition } from '@/private/client/hooks';
+import { RootServerContext } from '@/private/server/context';
 import { usePrivateLocation, useUniversalContext } from '@/private/universal/hooks';
 import type { CustomNavigator } from '@/private/universal/types/util';
 import { populatePathSegments } from '@/private/universal/utils/paths';
+import { useContext } from 'react';
 
 const useParams = <
   TParams extends Record<string, unknown> | Array<string> = Record<
@@ -60,11 +64,11 @@ interface RedirectOptions
 }
 
 const useRedirect = () => {
+  const populatePathname = usePopulatePathname();
+
   // @ts-expect-error The `Netlify` global only exists in the Netlify environment.
   const isNetlify = typeof Netlify !== 'undefined';
   if (typeof window === 'undefined' || isNetlify) {
-    const populatePathname = usePopulatePathname();
-
     return (pathname: string, options?: Pick<RedirectOptions, 'extraParams'>): never => {
       const populatedPathname = populatePathname(pathname, options?.extraParams);
 
@@ -73,7 +77,6 @@ const useRedirect = () => {
   }
 
   const transitionPage = usePageTransition();
-  const populatePathname = usePopulatePathname();
 
   return (pathname: string, options?: RedirectOptions) => {
     const populatedPathname = populatePathname(pathname, options?.extraParams);
@@ -84,4 +87,68 @@ const useRedirect = () => {
   };
 };
 
-export { useLocation, useNavigator, useParams, usePopulatePathname, useRedirect };
+export type CookieHookOptions = {
+  /**
+   * Allows for making cookies accessible to the client, instead of allowing only the
+   * server to read and modify them.
+   */
+  client?: true;
+  /**
+   * Allows for restricting the cookie to a specific URL path of the app.
+   *
+   * @default '/'
+   */
+  path?: string;
+};
+
+const useCookie = <T extends string | null>(
+  name: string,
+): [T | null, (value: T, options?: CookieHookOptions) => void] => {
+  const serverContext = useContext(RootServerContext);
+  if (!serverContext) throw new Error('Missing server context in `useCookie`');
+
+  const { cookies, collected } = serverContext;
+  const value = cookies[name] as T | null;
+
+  const setValue = (value: T, options?: CookieHookOptions) => {
+    const cookieSettings: CookieSerializeOptions = {
+      // 365 days.
+      maxAge: 31536000,
+      httpOnly: !options?.client,
+      path: options?.path || '/',
+    };
+
+    // To delete cookies, we have to set their expiration time to the past.
+    if (value === null) {
+      cookieSettings.expires = new Date(Date.now() - 1000000);
+      delete cookieSettings.maxAge;
+    }
+    // As per the types defined for the surrounding function, this condition would never
+    // be met. But we'd like to keep it regardless, to catch cases where the types
+    // provided to the developer aren't smart enough to avoid `undefined` or similar
+    // getting passed.
+    else if (typeof value !== 'string') {
+      let message = 'Cookies can only be set to a string value, or `null` ';
+      message += `for deleting them. Please adjust "${name}".`;
+      throw new Error(message);
+    }
+
+    if (!collected.cookies) collected.cookies = {};
+
+    collected.cookies[name] = {
+      value,
+      ...cookieSettings,
+    };
+  };
+
+  return [value, setValue];
+};
+
+export {
+  useLocation,
+  useNavigator,
+  useParams,
+  usePopulatePathname,
+  useRedirect,
+  useCookie,
+};


### PR DESCRIPTION
This change ensures that the `useCookie` hook already available on the server also starts working client-side.