### PR TITLE
Prevent server errors for event handlers

### DIFF
--- a/private/server/utils/serializer.ts
+++ b/private/server/utils/serializer.ts
@@ -835,16 +835,6 @@ const jsxPropsParents = new WeakMap();
 const jsxChildrenParents = new WeakMap();
 
 function attemptResolveElement(request, type, key, ref, props) {
-  /*
-  if (ref !== null && ref !== undefined) {
-    // When the ref moves to the regular props object this will implicitly
-    // throw for functions. We could probably relax it to a DEV warning for other
-    // cases.
-    throw new Error(
-      'Refs cannot be used in Server Components, nor passed to Client Components.',
-    );
-  }
-  */
   jsxPropsParents.set(props, type);
 
   if (typeof props.children === 'object' && props.children !== null) {
@@ -1362,18 +1352,15 @@ function resolveModelToJSON(request, parent, key, defaultValue) {
   }
 
   if (typeof value === 'function') {
+    // If the component is marked as interactive, reference the respective part of the
+    // client-side chunks.
     if (isClientReference(value)) {
       return serializeClientReference(request, value);
     }
 
-    if (/^on[A-Z]/.test(key)) {
-      throw new Error(
-        `Event handlers cannot be passed to Client Component props.${describeObjectForErrorMessage(parent, key)}\nIf you need interactivity, consider converting part of this to a Client Component.`,
-      );
-    }
-    throw new Error(
-      `Functions cannot be passed directly to Client Components because they're not serializable.${describeObjectForErrorMessage(parent, key)}`,
-    );
+    // If the component is not marked as interactive, ignore the function, since it
+    // won't be available in the client-side chunks.
+    return undefined;
   }
 
   if (typeof value === 'symbol') {

--- a/private/server/utils/serializer.ts
+++ b/private/server/utils/serializer.ts
@@ -835,6 +835,7 @@ const jsxPropsParents = new WeakMap();
 const jsxChildrenParents = new WeakMap();
 
 function attemptResolveElement(request, type, key, ref, props) {
+  /*
   if (ref !== null && ref !== undefined) {
     // When the ref moves to the regular props object this will implicitly
     // throw for functions. We could probably relax it to a DEV warning for other
@@ -843,6 +844,7 @@ function attemptResolveElement(request, type, key, ref, props) {
       'Refs cannot be used in Server Components, nor passed to Client Components.',
     );
   }
+  */
   jsxPropsParents.set(props, type);
 
   if (typeof props.children === 'object' && props.children !== null) {


### PR DESCRIPTION
This change ensures that components receiving functions via arguments render on the server without errors.

If a component is desired to be interactive, it can be marked as a client component. Not doing so should work fine too, and not cause an error.