### PR TITLE
Add default path to client-side `useCookie` setter

### DIFF
--- a/docs/components/copy.client.tsx
+++ b/docs/components/copy.client.tsx
@@ -18,6 +18,7 @@ export const CopyToClipboard = ({ content }: { content: string }) => {
     <Tooltip>
       <TooltipTrigger>
         <Button
+          asChild={true}
           variant="ghost"
           size="icon"
           onClick={handleCopy}>

--- a/docs/components/footer.tsx
+++ b/docs/components/footer.tsx
@@ -1,4 +1,4 @@
-import { useCookie, useLocation } from '@ronin/blade/hooks';
+import { useLocation } from '@ronin/blade/hooks';
 import { Edit } from 'lucide-react';
 
 import { Icons } from '@/components/icons';
@@ -14,11 +14,13 @@ function getEditUrl(location: URL): string {
   return location.pathname;
 }
 
-export const Footer = () => {
+interface FooterProps {
+  theme?: Theme | null;
+}
+
+export const Footer = (props: FooterProps) => {
   const location = useLocation();
   const pathname = getEditUrl(location);
-
-  const [theme] = useCookie<Theme>('theme');
 
   return (
     <footer className="mx-auto w-full max-w-2xl space-y-10 pb-16">
@@ -39,7 +41,7 @@ export const Footer = () => {
         </p>
 
         <div className="flex gap-4">
-          <ThemeToggle initial={theme} />
+          <ThemeToggle initial={props.theme} />
 
           <Button
             asChild={true}

--- a/docs/components/theme-toggle.client.tsx
+++ b/docs/components/theme-toggle.client.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle(props: ThemeToggleProps) {
     const updatedTheme = themeCookie === 'dark' ? 'light' : 'dark';
 
     setTheme(updatedTheme);
-    setThemeCookie(updatedTheme, { client: true });
+    setThemeCookie(updatedTheme, { client: true, path: '/' });
 
     if (document.documentElement.classList.contains('dark' satisfies Theme)) {
       document.documentElement.classList.remove('dark');
@@ -37,7 +37,7 @@ export function ThemeToggle(props: ThemeToggleProps) {
     const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const initialTheme = systemPrefersDark ? 'dark' : 'light';
     setTheme(initialTheme);
-    setThemeCookie(initialTheme, { client: true });
+    setThemeCookie(initialTheme, { client: true, path: '/' });
   }, []);
 
   return (

--- a/docs/components/theme-toggle.client.tsx
+++ b/docs/components/theme-toggle.client.tsx
@@ -18,7 +18,7 @@ export function ThemeToggle(props: ThemeToggleProps) {
     const updatedTheme = themeCookie === 'dark' ? 'light' : 'dark';
 
     setTheme(updatedTheme);
-    setThemeCookie(updatedTheme, { client: true, path: '/' });
+    setThemeCookie(updatedTheme, { client: true });
 
     if (document.documentElement.classList.contains('dark' satisfies Theme)) {
       document.documentElement.classList.remove('dark');
@@ -37,7 +37,7 @@ export function ThemeToggle(props: ThemeToggleProps) {
     const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const initialTheme = systemPrefersDark ? 'dark' : 'light';
     setTheme(initialTheme);
-    setThemeCookie(initialTheme, { client: true, path: '/' });
+    setThemeCookie(initialTheme, { client: true });
   }, []);
 
   return (

--- a/docs/components/ui/button.tsx
+++ b/docs/components/ui/button.tsx
@@ -1,5 +1,6 @@
 import { Slot } from '@radix-ui/react-slot';
 import { type VariantProps, cva } from 'class-variance-authority';
+import { forwardRef } from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -32,25 +33,24 @@ const buttonVariants = cva(
   },
 );
 
-function Button({
-  className,
-  variant,
-  size,
-  asChild = false,
-  ...props
-}: React.ComponentProps<'button'> &
+type ButtonProps = React.ComponentProps<'button'> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean;
-  }) {
-  const Comp = asChild ? Slot : 'button';
+  };
 
-  return (
-    <Comp
-      data-slot="button"
-      className={cn(buttonVariants({ variant, size, className }))}
-      {...props}
-    />
-  );
-}
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+
+    return (
+      <Comp
+        data-slot="button"
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
 
 export { Button };

--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -160,7 +160,7 @@ const DocsLayout = ({
           <OnThisPage />
         </div>
         <div className="mt-16">
-          <Footer />
+          <Footer theme={theme} />
         </div>
       </div>
       <script

--- a/public/universal/hooks.ts
+++ b/public/universal/hooks.ts
@@ -165,7 +165,8 @@ const useCookie = <T extends string | null>(
       components.push(`max-age=${DEFAULT_COOKIE_MAX_AGE}`);
     }
 
-    if (options?.path) components.push(`path=${options.path}`);
+    const path = options?.path || '/';
+    components.push(`path=${path}`);
 
     document.cookie = components.join('; ');
   };


### PR DESCRIPTION
This change fixes a small bug with the `useCookie` hook where if no `options.path` property was provided on the client then no `path` would be set in the cookie, which does not match the server-logic.

Additionally this also applies a few smaller fixes for our documentation site, namely the following:
 - `CopyToClipboard` trigger button now enables `asChild`
 - Prop drill theme cookie initial value from layout
 - `Button` component now wrapped in `forwardRef`