### PR TITLE
Add description to documentation site

### DIFF
--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -121,6 +121,7 @@ const DocsLayout = ({
   useMetadata({
     htmlClassName: theme === 'dark' ? 'dark' : undefined,
     title,
+    description,
     icon: 'https://blade.im/static/black.png',
     openGraph: {
       title,


### PR DESCRIPTION
This change updates the `useMetadata` hook in the documentation sites root layout to add a `description` property to improve SEO.