### PR TITLE
Remove rounded corners from copy button

### DIFF
--- a/docs/components/copy.client.tsx
+++ b/docs/components/copy.client.tsx
@@ -23,9 +23,9 @@ export const CopyToClipboard = ({ content }: { content: string }) => {
           size="icon"
           onClick={handleCopy}>
           {isCopied ? (
-            <CheckIcon className="h-4 w-4" />
+            <CheckIcon className="h-4 w-4 rounded-none" />
           ) : (
-            <CopyIcon className="h-4 w-4" />
+            <CopyIcon className="h-4 w-4 rounded-none" />
           )}
         </Button>
       </TooltipTrigger>


### PR DESCRIPTION
The copy icon got cut off by the the rounded corners.