### PR TITLE
Ensure reliable theme selection

### DIFF
--- a/docs/components/theme-toggle.client.tsx
+++ b/docs/components/theme-toggle.client.tsx
@@ -41,7 +41,7 @@ export function ThemeToggle(props: ThemeToggleProps) {
     }
   }, [themeCookie, setThemeCookie]);
 
-  const Icon = MAPPED_THEME_ICON[theme ?? 'system'];
+  const Icon = MAPPED_THEME_ICON[theme] ?? Monitor;
 
   return (
     <Button

--- a/docs/components/theme-toggle.client.tsx
+++ b/docs/components/theme-toggle.client.tsx
@@ -2,7 +2,7 @@ import { useCookie } from '@ronin/blade/hooks';
 import { Monitor, MoonIcon, SunIcon } from 'lucide-react';
 import { useCallback, useState } from 'react';
 
-import { Button } from './ui/button';
+import { Button } from '@/components/ui/button';
 
 import type { LucideProps } from 'lucide-react';
 import type { ForwardRefExoticComponent, RefAttributes } from 'react';

--- a/docs/components/theme-toggle.client.tsx
+++ b/docs/components/theme-toggle.client.tsx
@@ -1,17 +1,29 @@
 import { useCookie } from '@ronin/blade/hooks';
-import { MoonIcon, SunIcon } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { Monitor, MoonIcon, SunIcon } from 'lucide-react';
+import { useCallback, useState } from 'react';
 
-import { Button } from '@/components/ui/button';
+import { Button } from './ui/button';
 
-export type Theme = 'light' | 'dark';
+import type { LucideProps } from 'lucide-react';
+import type { ForwardRefExoticComponent, RefAttributes } from 'react';
+
+export type Theme = 'light' | 'dark' | 'system';
 
 interface ThemeToggleProps {
   initial?: Theme | null;
 }
 
+const MAPPED_THEME_ICON = {
+  dark: MoonIcon,
+  light: SunIcon,
+  system: Monitor,
+} satisfies Record<
+  Theme,
+  ForwardRefExoticComponent<Omit<LucideProps, 'ref'> & RefAttributes<SVGSVGElement>>
+>;
+
 export function ThemeToggle(props: ThemeToggleProps) {
-  const [theme, setTheme] = useState<Theme | null>(props.initial ?? null);
+  const [theme, setTheme] = useState<Theme>(props.initial ?? 'system');
   const [themeCookie, setThemeCookie] = useCookie<Theme>('theme');
 
   const toggleTheme = useCallback((): void => {
@@ -22,23 +34,14 @@ export function ThemeToggle(props: ThemeToggleProps) {
 
     if (document.documentElement.classList.contains('dark' satisfies Theme)) {
       document.documentElement.classList.remove('dark');
+      document.documentElement.classList.add('light');
     } else {
       document.documentElement.classList.add('dark');
+      document.documentElement.classList.remove('light');
     }
   }, [themeCookie, setThemeCookie]);
 
-  // Set the initial theme based on the user's system preference if no cookie is set.
-  useEffect(() => {
-    if (themeCookie) {
-      setTheme(themeCookie);
-      return;
-    }
-
-    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const initialTheme = systemPrefersDark ? 'dark' : 'light';
-    setTheme(initialTheme);
-    setThemeCookie(initialTheme, { client: true });
-  }, []);
+  const Icon = MAPPED_THEME_ICON[theme ?? 'system'];
 
   return (
     <Button
@@ -46,12 +49,7 @@ export function ThemeToggle(props: ThemeToggleProps) {
       onClick={toggleTheme}
       size="icon"
       variant="ghost">
-      {theme === 'dark' ? (
-        <MoonIcon className="h-4 w-4 text-black dark:text-white" />
-      ) : null}
-      {theme === 'light' ? (
-        <SunIcon className="h-4 w-4 text-black dark:text-white" />
-      ) : null}
+      <Icon className="h-4 w-4 text-black dark:text-white" />
       <span className="sr-only">Toggle theme</span>
     </Button>
   );

--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -119,7 +119,7 @@ const DocsLayout = ({
   const description = 'Build instant web apps.';
 
   useMetadata({
-    htmlClassName: theme ?? undefined,
+    htmlClassName: theme && ['dark', 'light'].includes(theme) ? theme : undefined,
     title,
     description,
     icon: 'https://blade.im/static/black.png',

--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -119,7 +119,7 @@ const DocsLayout = ({
   const description = 'Build instant web apps.';
 
   useMetadata({
-    htmlClassName: theme === 'dark' ? 'dark' : undefined,
+    htmlClassName: theme ?? undefined,
     title,
     description,
     icon: 'https://blade.im/static/black.png',

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3,7 +3,17 @@
 @import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap");
 @plugin "@tailwindcss/typography";
 
-@custom-variant dark (&:where(.dark, .dark *));
+@custom-variant dark {    
+    &:where(.dark, .dark *) {
+        @slot;
+    }
+
+    @media (prefers-color-scheme: dark) {
+        &:not(:where(.light, .light *)) {
+            @slot;
+        }
+    }
+}
 
 body,
 html {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -3,7 +3,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Geist:wght@100..900&display=swap");
 @plugin "@tailwindcss/typography";
 
-@custom-variant dark {    
+@custom-variant dark {
     &:where(.dark, .dark *) {
         @slot;
     }
@@ -93,7 +93,7 @@ html {
 	--sh-string: var(--color-sky-300);
 }
 
-.dark {
+@variant dark {
 	--background: oklch(0.145 0 0);
 	--foreground: oklch(0.985 0 0);
 	--card: oklch(0.145 0 0);
@@ -189,7 +189,7 @@ html {
 		--sidebar-border: 220 13% 91%;
 		--sidebar-ring: 217.2 91.2% 59.8%;
 	}
-	.dark {
+	@variant dark {
 		--sidebar-background: 240 5.9% 10%;
 		--sidebar-foreground: 240 4.8% 95.9%;
 		--sidebar-primary: 224.3 76.3% 48%;


### PR DESCRIPTION
This change updates our theme selection logic to default to the system preferred color scheme when no `theme` cookie exists. Otherwise we will add either a `light` or `dark` class to the top-level `html` element.