### PR TITLE
Fix documentation content spacing

### DIFF
--- a/docs/components/code.tsx
+++ b/docs/components/code.tsx
@@ -88,7 +88,7 @@ export const CodeBlock = (props: CodeBlockProps) => {
   });
 
   return (
-    <div className="relative">
+    <div className="relative my-6">
       <pre
         {...restProps}
         className="not-prose relative my-0! overflow-x-auto rounded-lg border p-5 text-sm">

--- a/docs/components/copy.client.tsx
+++ b/docs/components/copy.client.tsx
@@ -19,13 +19,14 @@ export const CopyToClipboard = ({ content }: { content: string }) => {
       <TooltipTrigger>
         <Button
           asChild={true}
+          className="h-6 w-6 cursor-pointer p-1.5"
           variant="ghost"
           size="icon"
           onClick={handleCopy}>
           {isCopied ? (
-            <CheckIcon className="h-4 w-4 rounded-none" />
+            <CheckIcon className="rounded-sm" />
           ) : (
-            <CopyIcon className="h-4 w-4 rounded-none" />
+            <CopyIcon className="rounded-sm" />
           )}
         </Button>
       </TooltipTrigger>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -34,6 +34,12 @@ html {
 		@apply dark:text-white;
 	}
 
+	h2,
+	h3,
+	h4 {
+		@apply scroll-mt-20;
+	}
+
 	p {
 		@apply leading-relaxed [&:not(:first-child)]:my-2 dark:text-[#9E9E9E] text-[#3E3E3E]
 	}

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -35,7 +35,7 @@ html {
 	}
 
 	p {
-		@apply leading-relaxed [&:not(:first-child)]:mt-4 dark:text-[#9E9E9E] text-[#3E3E3E]
+		@apply leading-relaxed [&:not(:first-child)]:my-2 dark:text-[#9E9E9E] text-[#3E3E3E]
 	}
 
 	code:not(pre code) {


### PR DESCRIPTION
This PR fixes both the hover styles of the copy button in code snippets, as well as the margin spacing between paragraphs. See the attached a screenshots for before & after.

![CleanShot 2025-06-17 at 1  29 43@2x](https://github.com/user-attachments/assets/48537a7a-8746-43eb-9846-0098a6d94f2b)
