### PR TITLE
Use a single build

### DIFF
--- a/docs/components/navbar.tsx
+++ b/docs/components/navbar.tsx
@@ -45,7 +45,7 @@ export const Navbar = ({ items }: { items: SidebarItem }) => {
               rel="noreferrer"
               className="w-fit px-0">
               <Icons.gitHub className="h-4 w-4" />
-              <span className="text-muted-foreground text-xs tabular-nums">140</span>
+              <span className="text-muted-foreground text-xs tabular-nums">197</span>
               <span className="sr-only">GitHub</span>
             </a>
           </Button>

--- a/private/client/index.ts
+++ b/private/client/index.ts
@@ -1,10 +1,8 @@
 import 'server-list';
+import { hydrateRoot } from 'react-dom/client';
 
 import '@/private/client/components/history';
 import '@/public/client/components';
-
-import { hydrateRoot } from 'react-dom/client';
-
 import fetchPage from '@/private/client/utils/fetch-page';
 
 if (!window['BLADE_ROOT']) {

--- a/private/client/types/global.d.ts
+++ b/private/client/types/global.d.ts
@@ -4,9 +4,6 @@ interface Window {
   // the browser.
   BLADE_ROOT: import('react-dom/client').Root | null;
 
-  // Contains the ID of the main bundle that is currently loaded on the client.
-  BLADE_BUNDLE: string;
-
   // Contains a list of all the chunks that were loaded on the client so far.
   BLADE_CHUNKS: Record<string, Record<string, unknown>>;
 }

--- a/private/client/utils/fetch-page.ts
+++ b/private/client/utils/fetch-page.ts
@@ -1,3 +1,4 @@
+import { bundleId } from 'build-meta';
 import { omit } from 'radash';
 import type { ReactNode } from 'react';
 
@@ -57,7 +58,7 @@ const fetchPage = async (
 
   const headers = new Headers({
     Accept: 'application/json',
-    'X-Client-Bundle-Id': window['BLADE_BUNDLE'],
+    'X-Client-Bundle-Id': bundleId,
   });
 
   const response = await fetchRetry(path, { method: 'POST', body, headers });

--- a/private/client/utils/fetch-page.ts
+++ b/private/client/utils/fetch-page.ts
@@ -23,7 +23,7 @@ const loadResource = async (bundleId: string, type: 'style' | 'script') => {
     link.as = type;
     link.onload = resolve;
     link.onerror = reject;
-    link.href = getOutputFile(bundleId, type === 'style' ? 'css' : 'js');
+    link.href = `/${getOutputFile(bundleId, type === 'style' ? 'css' : 'js')}`;
 
     document.head.appendChild(link);
   });

--- a/private/client/utils/wrap-client.ts
+++ b/private/client/utils/wrap-client.ts
@@ -30,6 +30,7 @@ export const wrapClientComponent = (component: Component, name: string) => {
       },
     );
   } else {
+    if (!window['BLADE_CHUNKS']) window['BLADE_CHUNKS'] = {};
     window.BLADE_CHUNKS[chunkId] = { [name]: component };
   }
 };

--- a/private/server/components/root.tsx
+++ b/private/server/components/root.tsx
@@ -27,8 +27,8 @@ const metadataNames: Record<string, string> = {
 };
 
 const ASSETS = new Array<Asset>(
-  { type: 'js', source: getOutputFile(bundleId, 'js') },
-  { type: 'css', source: getOutputFile(bundleId, 'css') },
+  { type: 'js', source: `/${getOutputFile(bundleId, 'js')}` },
+  { type: 'css', source: `/${getOutputFile(bundleId, 'css')}` },
 );
 
 // In production, load the service worker script.

--- a/private/server/components/root.tsx
+++ b/private/server/components/root.tsx
@@ -1,3 +1,4 @@
+import { bundleId } from 'build-meta';
 import { flatten } from 'flat';
 import type { ReactNode } from 'react';
 
@@ -8,6 +9,7 @@ import type { PageMetadata, RecursiveRequired, ValueOf } from '@/private/server/
 import { getSerializableContext } from '@/private/universal/context';
 import { usePrivateLocation } from '@/private/universal/hooks';
 import type { Asset } from '@/private/universal/types/util';
+import { getOutputFile } from '@/private/universal/utils/paths';
 
 const metadataNames: Record<string, string> = {
   colorScheme: 'color-scheme',
@@ -24,8 +26,16 @@ const metadataNames: Record<string, string> = {
   'openGraph.siteName': 'og:site_name',
 };
 
-// Perform the parsing once instead of on every render.
-const ASSETS = JSON.parse(import.meta.env.__BLADE_ASSETS) as Array<Asset>;
+const ASSETS = new Array<Asset>(
+  { type: 'js', source: getOutputFile(bundleId, 'js') },
+  { type: 'css', source: getOutputFile(bundleId, 'css') },
+);
+
+// In production, load the service worker script.
+if (import.meta.env['__BLADE_SERVICE_WORKER'] === 'true') {
+  ASSETS.push({ type: 'worker', source: '/service-worker.js' });
+}
+
 const SERVICE_WORKER = ASSETS.find((asset) => asset.type === 'worker');
 
 interface RootProps {

--- a/private/server/worker/index.ts
+++ b/private/server/worker/index.ts
@@ -45,7 +45,8 @@ app.use('*', async (c, next) => {
   // before the pages.
   if (
     typeof c.env?.['ASSETS'] !== 'undefined' &&
-    (requestPath.startsWith(CLIENT_ASSET_PREFIX) || requestPath.startsWith('/static'))
+    (requestPath.startsWith(`/${CLIENT_ASSET_PREFIX}`) ||
+      requestPath.startsWith('/static'))
   ) {
     const newRequest = new Request(requestOrigin + requestPath, c.req.raw);
     const response = await c.env['ASSETS'].fetch(newRequest);

--- a/private/server/worker/tree.ts
+++ b/private/server/worker/tree.ts
@@ -1,4 +1,5 @@
 import type { Toc } from '@stefanprobst/rehype-extract-toc';
+import { bundleId } from 'build-meta';
 import { type CookieSerializeOptions, serialize as serializeCookie } from 'cookie';
 import getValue from 'get-value';
 import type { Context } from 'hono';
@@ -742,7 +743,7 @@ const renderReactTree = async (
   const clientBundle = c.req.raw.headers.get('X-Client-Bundle-Id');
 
   // The ID of the main bundle currently available on the server.
-  const serverBundle = import.meta.env.__BLADE_ASSETS_ID;
+  const serverBundle = bundleId;
 
   // If the application is being rendered for the first time, we want to render it as
   // static markup. The same should happen if a new main bundle is available on the

--- a/private/shell/constants.ts
+++ b/private/shell/constants.ts
@@ -2,8 +2,6 @@ import path from 'node:path';
 import chalk from 'chalk';
 import gradient from 'gradient-string';
 
-import { CLIENT_ASSET_PREFIX } from '@/private/universal/utils/constants';
-
 export const pagesDirectory = path.resolve(process.cwd(), 'pages');
 export const componentsDirectory = path.resolve(process.cwd(), 'components');
 export const triggersDirectory = path.resolve(process.cwd(), 'triggers');
@@ -17,7 +15,6 @@ export const directoriesToParse = {
 };
 
 export const outputDirectory = path.resolve(process.cwd(), '.blade');
-export const clientOutputDirectory = path.join(outputDirectory, CLIENT_ASSET_PREFIX);
 
 // The path at which people can define a custom Hono app that Blade will mount.
 export const routerInputFile = path.join(process.cwd(), 'router.ts');

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -254,9 +254,13 @@ if (isBuilding || isDeveloping) {
           build.onEnd(async (result) => {
             // Only rebuild client if server build succeeded.
             if (result.errors.length === 0) {
-              // Start evaluating the server module immediately.
+              // Start evaluating the server module immediately. We're passing a query
+              // parameter in order to skip the import cache.
               server.module = import(
-                path.join(outputDirectory, `${defaultDeploymentProvider}.js`)
+                path.join(
+                  outputDirectory,
+                  `${defaultDeploymentProvider}.js?t=${Date.now()}`,
+                )
               );
 
               await clientBuild.rebuild();

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -254,14 +254,11 @@ if (isBuilding || isDeveloping) {
           build.onEnd(async (result) => {
             // Only rebuild client if server build succeeded.
             if (result.errors.length === 0) {
-              // Start evaluating the server module immediately. We're passing a query
-              // parameter in order to skip the import cache.
-              server.module = import(
-                path.join(
-                  outputDirectory,
-                  `${defaultDeploymentProvider}.js?t=${Date.now()}`,
-                )
-              );
+              // We're passing a query parameter in order to skip the import cache.
+              const moduleName = `${defaultDeploymentProvider}.js?t=${Date.now()}`;
+
+              // Start evaluating the server module immediately.
+              server.module = import(path.join(outputDirectory, moduleName));
 
               await clientBuild.rebuild();
 

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -230,6 +230,7 @@ if (isBuilding || isDeveloping) {
       isBuilding,
       isServing,
       isLoggingQueries: values.queries || false,
+
       projects,
       provider,
     }),

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -173,6 +173,7 @@ if (isBuilding || isDeveloping) {
         out: outputDirectory,
       },
     ],
+    outdir: outputDirectory,
     sourcemap: 'external',
     bundle: true,
     format: 'esm',
@@ -198,7 +199,7 @@ if (isBuilding || isDeveloping) {
 
           build.onLoad({ filter: /^build-meta$/, namespace: 'dynamic-meta' }, () => {
             return {
-              contents: `export const BUNDLE_ID = "${bundleId}";`,
+              contents: `export const bundleId = "${bundleId}";`,
               loader: 'ts',
               resolveDir: process.cwd(),
             };
@@ -230,6 +231,8 @@ if (isBuilding || isDeveloping) {
       provider,
     }),
   });
+
+  await mainBuild.rebuild();
 
   const ignored = ['node_modules', '.git', '.blade', '.husky', '.vercel'];
 

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -36,8 +36,8 @@ import {
   transformToNetlifyOutput,
   transformToVercelBuildOutput,
 } from '@/private/shell/utils/providers';
-import { CLIENT_ASSET_PREFIX } from '@/private/universal/utils/constants';
 import { generateUniqueId } from '@/private/universal/utils/crypto';
+import { getOutputFile } from '@/private/universal/utils/paths';
 
 // We want people to add BLADE to `package.json`, which, for example, ensures that
 // everyone in a team is using the same version when working on apps.
@@ -166,7 +166,7 @@ if (isBuilding || isDeveloping) {
     entryPoints: [
       {
         in: clientInputFile,
-        out: path.join(CLIENT_ASSET_PREFIX, 'main'),
+        out: getOutputFile('init'),
       },
       {
         in: path.join(serverInputFolder, `${defaultDeploymentProvider}.js`),
@@ -207,15 +207,20 @@ if (isBuilding || isDeveloping) {
 
           build.onEnd(async (result) => {
             if (result.errors.length === 0) {
-              const clientOutputDir = path.join(outputDirectory, CLIENT_ASSET_PREFIX);
-              const clientBundle = path.join(clientOutputDir, 'main.js');
-              const clientSourcemap = path.join(clientOutputDir, 'main.js.map');
+              const clientBundle = path.join(
+                outputDirectory,
+                getOutputFile('init', 'js'),
+              );
+              const clientSourcemap = path.join(
+                outputDirectory,
+                getOutputFile('init', 'js.map'),
+              );
 
               await Promise.all([
-                rename(clientBundle, path.join(clientOutputDir, `main.${bundleId}.js`)),
+                rename(clientBundle, clientBundle.replace('init.js', `${bundleId}.js`)),
                 rename(
                   clientSourcemap,
-                  path.join(clientOutputDir, `main.${bundleId}.js.map`),
+                  clientSourcemap.replace('init.js.map', `${bundleId}.js.map`),
                 ),
               ]);
 

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -27,7 +27,7 @@ import {
 } from '@/private/shell/loaders';
 import {
   cleanUp,
-  getClientEnvironmentVariables,
+  composeEnvironmentVariables,
   logSpinner,
   prepareStyles,
 } from '@/private/shell/utils';
@@ -226,7 +226,7 @@ if (isBuilding || isDeveloping) {
         },
       },
     ],
-    define: getClientEnvironmentVariables({
+    define: composeEnvironmentVariables({
       isBuilding,
       isServing,
       isLoggingQueries: values.queries || false,

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -160,8 +160,6 @@ if (isBuilding || isDeveloping) {
 
   await cleanUp();
 
-  const projects = JSON.parse(import.meta.env['__BLADE_PROJECTS']) as string[];
-
   const assets = new Array<Asset>(
     { type: 'js', source: getOutputFile(bundleId, 'js') },
     { type: 'css', source: getOutputFile(bundleId, 'css') },
@@ -230,8 +228,6 @@ if (isBuilding || isDeveloping) {
       isBuilding,
       isServing,
       isLoggingQueries: values.queries || false,
-
-      projects,
       provider,
     }),
   });

--- a/private/shell/listener.ts
+++ b/private/shell/listener.ts
@@ -47,10 +47,10 @@ export const serve = async (
     );
   }
 
-  const clientPathPrefix = new RegExp(`^${CLIENT_ASSET_PREFIX}`);
+  const clientPathPrefix = new RegExp(`^\/${CLIENT_ASSET_PREFIX}`);
   app.use('*', serveStatic({ root: path.basename(publicDirectory) }));
   app.use(
-    `${CLIENT_ASSET_PREFIX}/*`,
+    `/${CLIENT_ASSET_PREFIX}/*`,
     serveStatic({
       // It's extremely important for requests to be scoped to the client output.
       // directory, since server code could otherwise be read.

--- a/private/shell/loaders.ts
+++ b/private/shell/loaders.ts
@@ -27,11 +27,10 @@ export const getClientReferenceLoader = (): esbuild.Plugin => ({
       contents = contents.replaceAll(/export {([\s\S]*?)}/g, '');
       contents = contents.replaceAll(/export /g, '');
 
-      const relativeSourcePath = path.relative(process.cwd(), source.path);
       const chunkId = generateUniqueId();
 
       for (const exportItem of exports) {
-        contents += `${wrapClientExport(exportItem, { id: chunkId, path: relativeSourcePath })}\n`;
+        contents += `${wrapClientExport(exportItem, chunkId)}\n`;
 
         const usableName = exportItem.originalName
           ? `${exportItem.originalName} as ${exportItem.name}`

--- a/private/shell/types.ts
+++ b/private/shell/types.ts
@@ -1,7 +1,5 @@
 export type FileError = { code: string };
 
-export type ClientChunks = Map<string, string>;
-
 type ServerlessFunctionConfig = {
   environment?: Array<Record<string, string>>;
   handler: string;

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -78,23 +78,22 @@ export const wrapClientExport = (exportItem: ExportItem, chunkId: string) => {
   const externalName = exportItem.name;
 
   return `
-  if (typeof window === 'undefined' || isNetlify) {
-    try {
-      Object.defineProperties(
-        ${internalName}.$$typeof === REACT_FORWARD_REF_TYPE ? ${internalName}.render : ${internalName},
-        {
-          $$typeof: { value: CLIENT_REFERENCE },
-          name: { value: '${externalName}' },
-          chunk: { value: '${chunkId}' }
-        }
-      );
-    } catch (err) {}
-  } else {
-    if (!window['BLADE_CHUNKS']) window['BLADE_CHUNKS'] = {};
-    if (!window.BLADE_CHUNKS["${chunkId}"]) window.BLADE_CHUNKS["${chunkId}"] = {};
-
-    window.BLADE_CHUNKS["${chunkId}"]["${externalName}"] = ${internalName};
-  }
+    if (typeof window === 'undefined' || isNetlify) {
+      try {
+        Object.defineProperties(
+          ${internalName}.$$typeof === REACT_FORWARD_REF_TYPE ? ${internalName}.render : ${internalName},
+          {
+            $$typeof: { value: CLIENT_REFERENCE },
+            name: { value: '${externalName}' },
+            chunk: { value: '${chunkId}' }
+          }
+        );
+      } catch (err) {}
+    } else {
+      if (!window['BLADE_CHUNKS']) window['BLADE_CHUNKS'] = {};
+      if (!window.BLADE_CHUNKS["${chunkId}"]) window.BLADE_CHUNKS["${chunkId}"] = {};
+      window.BLADE_CHUNKS["${chunkId}"]["${externalName}"] = ${internalName};
+    }
   `;
 };
 

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -17,7 +17,7 @@ import {
   styleInputFile,
 } from '@/private/shell/constants';
 import type { FileError } from '@/private/shell/types';
-import { getProvider } from '@/private/shell/utils/providers';
+import type { DeploymentProvider } from '@/private/universal/types/util';
 import { getOutputFile } from '@/private/universal/utils/paths';
 
 const crawlDirectory = async (directory: string): Promise<string[]> => {
@@ -80,7 +80,15 @@ export const wrapClientExport = (
   const internalName = exportItem.originalName || exportItem.name;
   const externalName = exportItem.name;
 
-  return `try {
+  return `
+  const CLIENT_REFERENCE = Symbol.for('react.client.reference');
+  const REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref');
+   
+  const isNetlify = typeof Netlify !== 'undefined';
+
+  if (typeof window === 'undefined' || isNetlify) {
+
+    try {
     Object.defineProperties(
       ${internalName}.$$typeof === REACT_FORWARD_REF_TYPE ? ${internalName}.render : ${internalName},
       {
@@ -90,7 +98,16 @@ export const wrapClientExport = (
         id: { value: '${chunk.path}' }
       }
     );
-  } catch (err) {}`;
+  } catch (err) {}
+
+
+  } else {
+
+    if (!window.BLADE_CHUNKS["${chunk.id}"]) window.BLADE_CHUNKS["${chunk.id}"] = {};
+    window.BLADE_CHUNKS["${chunk.id}"]["${externalName}"] = ${internalName};
+
+  }
+  `;
 };
 
 interface ExportItem {
@@ -124,15 +141,22 @@ export const scanExports = (transpiler: Transpiler, code: string): ExportItem[] 
   });
 };
 
-// Collect the list of variables that will automatically be replaced in the client and
-// server bundles.
-export const setEnvironmentVariables = (options: {
+export const getClientEnvironmentVariables = (options: {
   isBuilding: boolean;
   isServing: boolean;
   isLoggingQueries: boolean;
   projects: string[];
-}) => {
-  if (import.meta.env['BLADE_ENV']) {
+  provider: DeploymentProvider;
+}): Record<string, string> => {
+  const { provider } = options;
+
+  const filteredVariables = Object.entries(Bun.env).filter(([key]) => {
+    return key.startsWith('BLADE_PUBLIC_') || key === 'BLADE_ENV';
+  }) as Array<[string, string]>;
+
+  const defined = Object.fromEntries(filteredVariables);
+
+  if (Bun.env['BLADE_ENV']) {
     let message = `${loggingPrefixes.error} The \`BLADE_ENV\` environment variable is provided by BLADE`;
     message += ` and cannot be overwritten. Using the \`blade\` command for "development"`;
     message += ` and \`blade build\` for "production" will automatically infer the value.`;
@@ -140,50 +164,46 @@ export const setEnvironmentVariables = (options: {
     process.exit(0);
   }
 
-  // Get the current provider based on the environment variables.
-  const provider = getProvider();
-  import.meta.env.__BLADE_PROVIDER = provider;
+  defined['__BLADE_PROVIDER'] = provider;
 
   if (provider === 'cloudflare') {
-    import.meta.env['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['CF_PAGES_BRANCH'] ?? '';
-    import.meta.env['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['CF_PAGES_COMMIT_SHA'] ?? '';
+    defined['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['CF_PAGES_BRANCH'] ?? '';
+    defined['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['CF_PAGES_COMMIT_SHA'] ?? '';
   }
 
   if (provider === 'netlify') {
-    import.meta.env['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['BRANCH'] ?? '';
-    import.meta.env['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['COMMIT_REF'] ?? '';
+    defined['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['BRANCH'] ?? '';
+    defined['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['COMMIT_REF'] ?? '';
   }
 
   if (provider === 'vercel') {
-    import.meta.env['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['VERCEL_GIT_COMMIT_REF'];
-    import.meta.env['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['VERCEL_GIT_COMMIT_SHA'];
+    defined['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['VERCEL_GIT_COMMIT_REF'] ?? '';
+    defined['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['VERCEL_GIT_COMMIT_SHA'] ?? '';
   }
 
-  import.meta.env.BLADE_DATA_WORKER ??= 'https://data.ronin.co';
-  import.meta.env.BLADE_STORAGE_WORKER ??= 'https://storage.ronin.co';
+  defined['BLADE_DATA_WORKER'] ??= 'https://data.ronin.co';
+  defined['BLADE_STORAGE_WORKER'] ??= 'https://storage.ronin.co';
 
   // Used by dependencies and the application itself to understand which environment the
   // application is currently running in.
   const environment =
     options.isBuilding || options.isServing ? 'production' : 'development';
-  import.meta.env['NODE_ENV'] = environment;
-  import.meta.env['BUN_ENV'] = environment;
-  import.meta.env['BLADE_ENV'] = environment;
+  defined['NODE_ENV'] = environment;
+  defined['BUN_ENV'] = environment;
+  defined['BLADE_ENV'] = environment;
 
   // This variable is used internally by BLADE to determine how much information should
   // be logged to the terminal.
-  import.meta.env['__BLADE_DEBUG_LEVEL'] = options.isLoggingQueries ? 'verbose' : 'error';
+  defined['__BLADE_DEBUG_LEVEL'] = options.isLoggingQueries ? 'verbose' : 'error';
 
   // The directories that contain the source code of the application.
-  import.meta.env['__BLADE_PROJECTS'] = JSON.stringify(options.projects);
-};
+  defined['__BLADE_PROJECTS'] = JSON.stringify(options.projects);
 
-export const getClientEnvironmentVariables = () => {
-  const filteredVariables = Object.entries(import.meta.env).filter(([key]) => {
-    return key.startsWith('BLADE_PUBLIC_') || key === 'BLADE_ENV';
+  const mapped = Object.entries(defined).map(([key, value]) => {
+    return [`import.meta.env.${key}`, JSON.stringify(value)];
   });
 
-  return Object.fromEntries(filteredVariables);
+  return Object.fromEntries(mapped);
 };
 
 export const logSpinner = (text: string) => {

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -145,10 +145,9 @@ export const composeEnvironmentVariables = (options: {
   isBuilding: boolean;
   isServing: boolean;
   isLoggingQueries: boolean;
-  projects: string[];
   provider: DeploymentProvider;
 }): Record<string, string> => {
-  const { provider } = options;
+  const { provider, isBuilding, isServing, isLoggingQueries } = options;
 
   const filteredVariables = Object.entries(Bun.env).filter(([key]) => {
     return key.startsWith('BLADE_PUBLIC_') || key === 'BLADE_ENV';
@@ -186,18 +185,14 @@ export const composeEnvironmentVariables = (options: {
 
   // Used by dependencies and the application itself to understand which environment the
   // application is currently running in.
-  const environment =
-    options.isBuilding || options.isServing ? 'production' : 'development';
+  const environment = isBuilding || isServing ? 'production' : 'development';
   defined['NODE_ENV'] = environment;
   defined['BUN_ENV'] = environment;
   defined['BLADE_ENV'] = environment;
 
   // This variable is used internally by BLADE to determine how much information should
   // be logged to the terminal.
-  defined['__BLADE_DEBUG_LEVEL'] = options.isLoggingQueries ? 'verbose' : 'error';
-
-  // The directories that contain the source code of the application.
-  defined['__BLADE_PROJECTS'] = JSON.stringify(options.projects);
+  defined['__BLADE_DEBUG_LEVEL'] = isLoggingQueries ? 'verbose' : 'error';
 
   const mapped = Object.entries(defined).map(([key, value]) => {
     return [`import.meta.env.${key}`, JSON.stringify(value)];

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -145,9 +145,11 @@ export const composeEnvironmentVariables = (options: {
   isBuilding: boolean;
   isServing: boolean;
   isLoggingQueries: boolean;
+  enableServiceWorker: boolean;
   provider: DeploymentProvider;
 }): Record<string, string> => {
-  const { provider, isBuilding, isServing, isLoggingQueries } = options;
+  const { provider, isBuilding, isServing, isLoggingQueries, enableServiceWorker } =
+    options;
 
   const filteredVariables = Object.entries(Bun.env).filter(([key]) => {
     return key.startsWith('BLADE_PUBLIC_') || key === 'BLADE_ENV';
@@ -164,6 +166,7 @@ export const composeEnvironmentVariables = (options: {
   }
 
   defined['__BLADE_PROVIDER'] = provider;
+  defined['__BLADE_SERVICE_WORKER'] = enableServiceWorker.toString();
 
   if (provider === 'cloudflare') {
     defined['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['CF_PAGES_BRANCH'] ?? '';

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -141,7 +141,7 @@ export const scanExports = (transpiler: Transpiler, code: string): ExportItem[] 
   });
 };
 
-export const getClientEnvironmentVariables = (options: {
+export const composeEnvironmentVariables = (options: {
   isBuilding: boolean;
   isServing: boolean;
   isLoggingQueries: boolean;

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -73,10 +73,7 @@ export const getFileList = async (): Promise<string> => {
   return file;
 };
 
-export const wrapClientExport = (
-  exportItem: ExportItem,
-  chunk: { id: string; path: string },
-) => {
+export const wrapClientExport = (exportItem: ExportItem, chunkId: string) => {
   const internalName = exportItem.originalName || exportItem.name;
   const externalName = exportItem.name;
 
@@ -88,16 +85,16 @@ export const wrapClientExport = (
         {
           $$typeof: { value: CLIENT_REFERENCE },
           name: { value: '${externalName}' },
-          chunk: { value: '${chunk.id}' },
-          id: { value: '${chunk.path}' }
+          chunk: { value: '${chunkId}' },
+          id: { value: '${chunkId}' }
         }
       );
     } catch (err) {}
   } else {
     if (!window['BLADE_CHUNKS']) window['BLADE_CHUNKS'] = {};
-    if (!window.BLADE_CHUNKS["${chunk.id}"]) window.BLADE_CHUNKS["${chunk.id}"] = {};
+    if (!window.BLADE_CHUNKS["${chunkId}"]) window.BLADE_CHUNKS["${chunkId}"] = {};
 
-    window.BLADE_CHUNKS["${chunk.id}"]["${externalName}"] = ${internalName};
+    window.BLADE_CHUNKS["${chunkId}"]["${externalName}"] = ${internalName};
   }
   `;
 };

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -85,8 +85,7 @@ export const wrapClientExport = (exportItem: ExportItem, chunkId: string) => {
         {
           $$typeof: { value: CLIENT_REFERENCE },
           name: { value: '${externalName}' },
-          chunk: { value: '${chunkId}' },
-          id: { value: '${chunkId}' }
+          chunk: { value: '${chunkId}' }
         }
       );
     } catch (err) {}

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -82,25 +82,22 @@ export const wrapClientExport = (
 
   return `
   if (typeof window === 'undefined' || isNetlify) {
-
     try {
-    Object.defineProperties(
-      ${internalName}.$$typeof === REACT_FORWARD_REF_TYPE ? ${internalName}.render : ${internalName},
-      {
-        $$typeof: { value: CLIENT_REFERENCE },
-        name: { value: '${externalName}' },
-        chunk: { value: '${chunk.id}' },
-        id: { value: '${chunk.path}' }
-      }
-    );
-  } catch (err) {}
-
-
+      Object.defineProperties(
+        ${internalName}.$$typeof === REACT_FORWARD_REF_TYPE ? ${internalName}.render : ${internalName},
+        {
+          $$typeof: { value: CLIENT_REFERENCE },
+          name: { value: '${externalName}' },
+          chunk: { value: '${chunk.id}' },
+          id: { value: '${chunk.path}' }
+        }
+      );
+    } catch (err) {}
   } else {
-
+    if (!window['BLADE_CHUNKS']) window['BLADE_CHUNKS'] = {};
     if (!window.BLADE_CHUNKS["${chunk.id}"]) window.BLADE_CHUNKS["${chunk.id}"] = {};
-    window.BLADE_CHUNKS["${chunk.id}"]["${externalName}"] = ${internalName};
 
+    window.BLADE_CHUNKS["${chunk.id}"]["${externalName}"] = ${internalName};
   }
   `;
 };

--- a/private/shell/utils/index.ts
+++ b/private/shell/utils/index.ts
@@ -81,11 +81,6 @@ export const wrapClientExport = (
   const externalName = exportItem.name;
 
   return `
-  const CLIENT_REFERENCE = Symbol.for('react.client.reference');
-  const REACT_FORWARD_REF_TYPE = Symbol.for('react.forward_ref');
-   
-  const isNetlify = typeof Netlify !== 'undefined';
-
   if (typeof window === 'undefined' || isNetlify) {
 
     try {

--- a/private/shell/utils/providers.ts
+++ b/private/shell/utils/providers.ts
@@ -23,33 +23,6 @@ export const getProvider = (): DeploymentProvider => {
 };
 
 /**
- * Inline environment variables for runtime environments like Cloudflare, which do not
- * implement support for `import.meta.env`.
- *
- * @param provider - The deployment provider to evaluate.
- *
- * @returns An object of environment variables to be inlined.
- */
-export const mapProviderInlineDefinitions = (
-  provider: DeploymentProvider,
-): Record<string, string> => {
-  if (provider === 'edge-worker') {
-    return {
-      'import.meta.env.__BLADE_ASSETS': JSON.stringify(import.meta.env.__BLADE_ASSETS),
-      'import.meta.env.__BLADE_ASSETS_ID': JSON.stringify(
-        import.meta.env.__BLADE_ASSETS_ID,
-      ),
-    };
-  }
-
-  return Object.fromEntries(
-    Object.entries(import.meta.env)
-      .filter(([key]) => key.startsWith('BLADE_') || key.startsWith('__BLADE_'))
-      .map(([key, value]) => [`import.meta.env.${key}`, JSON.stringify(value)]),
-  );
-};
-
-/**
  * Transform to Vercel build output API.
  *
  * @description This function is designed to run after a production build

--- a/private/universal/types/global.d.ts
+++ b/private/universal/types/global.d.ts
@@ -14,8 +14,6 @@ declare module 'bun' {
     __BLADE_ASSETS: string;
     __BLADE_ASSETS_ID: string;
     __BLADE_DEBUG_LEVEL: 'verbose' | 'error';
-    __BLADE_PORT: string;
-    __BLADE_PROJECTS: string;
     __BLADE_PROVIDER: import('./util').DeploymentProvider;
   }
 }

--- a/private/universal/types/global.d.ts
+++ b/private/universal/types/global.d.ts
@@ -11,9 +11,12 @@ declare module 'bun' {
     BLADE_ENV: 'development' | 'production';
 
     // Provided automatically by BLADE, but only for internal use.
-    __BLADE_ASSETS: string;
-    __BLADE_ASSETS_ID: string;
     __BLADE_DEBUG_LEVEL: 'verbose' | 'error';
     __BLADE_PROVIDER: import('./util').DeploymentProvider;
+    __BLADE_SERVICE_WORKER: string;
   }
+}
+
+declare module 'build-meta' {
+  export const bundleId: string;
 }

--- a/private/universal/utils/constants.ts
+++ b/private/universal/utils/constants.ts
@@ -1,4 +1,4 @@
-export const CLIENT_ASSET_PREFIX = '/client';
+export const CLIENT_ASSET_PREFIX = 'client';
 
 export const DEFAULT_PAGE_PATH = 'blade-default-pages';
 

--- a/private/universal/utils/paths.ts
+++ b/private/universal/utils/paths.ts
@@ -43,6 +43,6 @@ export const populatePathSegments = (
   return href === '/' ? href : href.replace(/\/$/, '');
 };
 
-export const getOutputFile = (bundleId: string, type?: 'js' | 'css') => {
-  return `/${CLIENT_ASSET_PREFIX}/main.${bundleId}${type ? `.${type}` : ''}`;
+export const getOutputFile = (bundleId: string, type?: string) => {
+  return `${CLIENT_ASSET_PREFIX}/main.${bundleId}${type ? `.${type}` : ''}`;
 };

--- a/private/universal/utils/paths.ts
+++ b/private/universal/utils/paths.ts
@@ -44,5 +44,5 @@ export const populatePathSegments = (
 };
 
 export const getOutputFile = (bundleId: string, type?: 'js' | 'css') => {
-  return `${CLIENT_ASSET_PREFIX}/main.${bundleId}${type ? `.${type}` : ''}`;
+  return `/${CLIENT_ASSET_PREFIX}/main.${bundleId}${type ? `.${type}` : ''}`;
 };

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   format: 'esm',
   clean: true,
   dts: true,
-  external: ['bun', 'server-list', 'client-list', 'react', 'react-dom'],
+  external: ['bun', 'server-list', 'build-meta', 'react', 'react-dom'],
   publicDir: './private/client/assets',
   treeshake: true,
 });


### PR DESCRIPTION
Instead of performing a server and a client build, this change ensures that we only perform one build, which allows for speeding up HMR (and builds in general) even further.