### PR TITLE
Align first heading with sidebar

### DIFF
--- a/docs/components/heading.client.tsx
+++ b/docs/components/heading.client.tsx
@@ -36,7 +36,7 @@ export const Heading = ({ children, level, ...props }: HeadingProps) => {
       data-heading={true}
       href={`#${id}`}
       id={id}
-      className="group -ml-11 not-prose relative mt-4 flex scroll-mt-25 items-center gap-2">
+      className="group -ml-11 not-prose relative flex scroll-mt-25 items-center gap-2 [&:not(:first-child)]:mt-4">
       <Button
         variant="ghost"
         size="sm"

--- a/docs/components/navbar.tsx
+++ b/docs/components/navbar.tsx
@@ -45,7 +45,7 @@ export const Navbar = ({ items }: { items: SidebarItem }) => {
               rel="noreferrer"
               className="w-fit px-0">
               <Icons.gitHub className="h-4 w-4" />
-              <span className="text-muted-foreground text-xs tabular-nums">197</span>
+              <span className="text-muted-foreground text-xs tabular-nums">213</span>
               <span className="sr-only">GitHub</span>
             </a>
           </Button>

--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -158,7 +158,7 @@ const DocsLayout = ({
         <div className="fixed top-24 left-6 w-fit">
           <Sidebar items={menuItems} />
         </div>
-        <div className="docs-content prose mx-auto flex w-full min-w-0 max-w-2xl flex-1 flex-col px-4 py-6 text-neutral-800 md:px-0 lg:py-8 dark:text-neutral-300">
+        <div className="docs-content prose mx-auto flex w-full min-w-0 max-w-2xl flex-1 flex-col px-4 py-6 text-neutral-800 md:px-0 dark:text-neutral-300">
           {children}
         </div>
         <div className="fixed top-24 right-20 w-40">


### PR DESCRIPTION
Align table of contents, the first heading and the sidebar. 
![CleanShot 2025-06-20 at 08 42 31@2x](https://github.com/user-attachments/assets/53a007ee-a600-4e8e-a203-7787cdb61095)
