### PR TITLE
Correctly serve app in containers

### DIFF
--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -230,7 +230,9 @@ if (isBuilding || isDeveloping) {
               // We're passing a query parameter in order to skip the import cache.
               const moduleName = `${defaultDeploymentProvider}.js?t=${Date.now()}`;
 
-              // Start evaluating the server module immediately (no `await`).
+              // Start evaluating the server module immediately. We're not using `await`
+              // to ensure that the client revalidation can begin before the module has
+              // been evaluated entirely.
               server.module = import(path.join(outputDirectory, moduleName));
 
               // Revalidate the client.


### PR DESCRIPTION
Now that https://github.com/ronin-co/blade/pull/187 and https://github.com/ronin-co/blade/pull/222 have landed, we can make `blade serve` work with esbuild builds.