### PR TITLE
Correctly watch files on WSL (Windows)

### DIFF
--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { cp, exists, rename } from 'node:fs/promises';
+import os from 'node:os';
 import path from 'node:path';
 import { parseArgs } from 'node:util';
 import { $ } from 'bun';
@@ -276,11 +277,16 @@ if (isBuilding || isDeveloping) {
   };
 
   if (isDeveloping) {
+    const isWsl =
+      process.platform === 'linux' && os.release().toLowerCase().includes('microsoft');
+
     chokidar
       .watch(process.cwd(), {
         ignored: (path) => ignored.some((item) => path.includes(item)),
         ignoreInitial: true,
-        usePolling: true,
+
+        // On WSL (Linux on Windows), we need to use polling for reliable file watching.
+        usePolling: isWsl,
       })
       .on('all', (event, eventPath) => {
         const eventMessage =

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -280,6 +280,7 @@ if (isBuilding || isDeveloping) {
       .watch(process.cwd(), {
         ignored: (path) => ignored.some((item) => path.includes(item)),
         ignoreInitial: true,
+        usePolling: true,
       })
       .on('all', (event, eventPath) => {
         const eventMessage =


### PR DESCRIPTION
This change adjusts the development server to use polling for watching files, in order to make HMR work on WSL.