### PR TITLE
Ensure correct hash links in docs

### DIFF
--- a/docs/components/toc-item.client.tsx
+++ b/docs/components/toc-item.client.tsx
@@ -13,12 +13,15 @@ export const TableOfContentsItem = ({
   const hash = slugify(heading.value);
 
   const handleHeadingClick: MouseEventHandler = (event) => {
+    // Prevent the browser from using the default scrolling effect.
     event.preventDefault();
-    const element = document.getElementById(hash);
 
     // Attach the hash to the current URL.
     document.location.hash = hash;
 
+    const element = document.getElementById(hash);
+
+    // Smoothly scroll to the element instead of scrolling abruptly.
     if (element) {
       element.scrollIntoView({
         behavior: 'smooth',


### PR DESCRIPTION
This change improves the links in the table of contents in the following ways:

- The links now show a cursor pointer instead of a default pointer.
- The links now work even before the JS is downloaded.
- The links now attach a hash component to the URL when clicked.

This resolves #202.