### PR TITLE
Fix `init` command

### DIFF
--- a/private/shell/constants.ts
+++ b/private/shell/constants.ts
@@ -7,7 +7,7 @@ export const componentsDirectory = path.resolve(process.cwd(), 'components');
 export const triggersDirectory = path.resolve(process.cwd(), 'triggers');
 export const publicDirectory = path.resolve(process.cwd(), 'public');
 
-export const frameworkDirectory = path.join(__dirname, '..');
+export const frameworkDirectory = path.join(__dirname, '..', '..', '..');
 
 export const directoriesToParse = {
   pages: pagesDirectory,

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -84,7 +84,6 @@ const enableServiceWorker = values.sw;
 const execAsync = promisify(exec);
 
 if (isInitializing) {
-  console.log(frameworkDirectory);
   const projectName = positionals[positionals.indexOf('init') + 1] ?? 'blade-example';
   const originDirectory = path.join(frameworkDirectory, 'examples', 'basic');
   const targetDirectory = path.join(process.cwd(), projectName);

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -85,7 +85,7 @@ const execAsync = promisify(exec);
 
 if (isInitializing) {
   const projectName = positionals[positionals.indexOf('init') + 1] ?? 'blade-example';
-  const originDirectory = path.join(frameworkDirectory, '..', 'examples', 'basic');
+  const originDirectory = path.join(frameworkDirectory, '..', '..', 'examples', 'basic');
   const targetDirectory = path.join(process.cwd(), projectName);
 
   const { stderr } = await execAsync(`cp -r ${originDirectory} ${targetDirectory}`);

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -84,8 +84,9 @@ const enableServiceWorker = values.sw;
 const execAsync = promisify(exec);
 
 if (isInitializing) {
+  console.log(frameworkDirectory);
   const projectName = positionals[positionals.indexOf('init') + 1] ?? 'blade-example';
-  const originDirectory = path.join(frameworkDirectory, '..', '..', 'examples', 'basic');
+  const originDirectory = path.join(frameworkDirectory, 'examples', 'basic');
   const targetDirectory = path.join(process.cwd(), projectName);
 
   const { stderr } = await execAsync(`cp -r ${originDirectory} ${targetDirectory}`);

--- a/private/shell/index.ts
+++ b/private/shell/index.ts
@@ -91,13 +91,6 @@ if (isInitializing) {
   const { stderr } = await execAsync(`cp -r ${originDirectory} ${targetDirectory}`);
 
   try {
-    await execAsync(`cd ${targetDirectory} && git init`);
-  } catch (error) {
-    logSpinner('Failed to initialize git repository. Is git installed?').fail();
-    console.error(error);
-  }
-
-  try {
     await Bun.write(
       path.join(targetDirectory, '.gitignore'),
       'node_modules\n.env\n.blade',


### PR DESCRIPTION
This PR resolves issues with the `init` command by correctly defining the path to example projects. It removes automatic git initialization and switches from bun primitives to Node for data copying.

