### PR TITLE
Correctly serialize elements

### DIFF
--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -27,10 +27,11 @@ export const getClientReferenceLoader = (): esbuild.Plugin => ({
       contents = contents.replaceAll(/export {([\s\S]*?)}/g, '');
       contents = contents.replaceAll(/export /g, '');
 
+      const relativeSourcePath = path.relative(process.cwd(), source.path);
       const chunkId = generateUniqueId();
 
       for (const exportItem of exports) {
-        contents += `${wrapClientExport(exportItem, chunkId)}\n`;
+        contents += `${wrapClientExport(exportItem, { id: chunkId, path: relativeSourcePath })}\n`;
 
         const usableName = exportItem.originalName
           ? `${exportItem.originalName} as ${exportItem.name}`

--- a/packages/blade/private/shell/utils/index.ts
+++ b/packages/blade/private/shell/utils/index.ts
@@ -80,7 +80,10 @@ export const getFileList = async (full?: boolean): Promise<string> => {
   return file;
 };
 
-export const wrapClientExport = (exportItem: ExportItem, chunkId: string) => {
+export const wrapClientExport = (
+  exportItem: ExportItem,
+  chunk: { id: string; path: string },
+) => {
   const internalName = exportItem.originalName || exportItem.name;
   const externalName = exportItem.name;
 
@@ -92,14 +95,15 @@ export const wrapClientExport = (exportItem: ExportItem, chunkId: string) => {
           {
             $$typeof: { value: CLIENT_REFERENCE },
             name: { value: '${externalName}' },
-            chunk: { value: '${chunkId}' }
+            chunk: { value: '${chunk.id}' },
+            id: { value: '${chunk.path}' }
           }
         );
       } catch (err) {}
     } else {
       if (!window['BLADE_CHUNKS']) window['BLADE_CHUNKS'] = {};
-      if (!window.BLADE_CHUNKS["${chunkId}"]) window.BLADE_CHUNKS["${chunkId}"] = {};
-      window.BLADE_CHUNKS["${chunkId}"]["${externalName}"] = ${internalName};
+      if (!window.BLADE_CHUNKS["${chunk.id}"]) window.BLADE_CHUNKS["${chunk.id}"] = {};
+      window.BLADE_CHUNKS["${chunk.id}"]["${externalName}"] = ${internalName};
     }
   `;
 };


### PR DESCRIPTION
In https://github.com/ronin-co/blade/pull/222, a regression was introduced that prevented pages with multiple client components from getting serialized correctly.

The change right here resolves that issue.