### PR TITLE
Add post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,20 @@
+name: Post Release
+
+on:
+  release:
+    types:
+     - published
+
+jobs:
+  post-to-discord:
+    name: Post Release to Discord
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Post release to Discord
+        uses: SethCohen/github-releases-to-discord@v1
+        with:
+          color: "16777215" #FFFFFF
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
This change adds a basic GitHub actions workflow to run every time a new release is created and post a message to `#releases` channel in [our Discord](https://discord.gg/ronin).