### PR TITLE
Refine Discord release message styles

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -16,4 +16,5 @@ jobs:
       - name: Post release to Discord
         uses: SethCohen/github-releases-to-discord@v1
         with:
+          color: "5347309" #5197ed
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
This change refines the styles for Discord release messages by setting the accent color to `#5197ed`.