### PR TITLE
Rely on Node.js APIs where possible

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -58,7 +58,8 @@
         "useGuardForIn": "off",
         "noHeadElement": "off",
         "noExportedImports": "off",
-        "noDocumentCookie": "off"
+        "noDocumentCookie": "off",
+        "noProcessEnv": "off"
       },
       "performance": {
         "all": true,

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -43,7 +43,7 @@ import { getOutputFile } from '@/private/universal/utils/paths';
 
 // We want people to add BLADE to `package.json`, which, for example, ensures that
 // everyone in a team is using the same version when working on apps.
-if (!Bun.env['npm_lifecycle_event']) {
+if (!process.env['npm_lifecycle_event']) {
   console.error(
     `${loggingPrefixes.error} The package must be installed locally, not globally.`,
   );
@@ -51,7 +51,7 @@ if (!Bun.env['npm_lifecycle_event']) {
 }
 
 const { values, positionals } = parseArgs({
-  args: Bun.argv,
+  args: process.argv,
   options: {
     debug: {
       type: 'boolean',
@@ -63,7 +63,7 @@ const { values, positionals } = parseArgs({
     },
     port: {
       type: 'string',
-      default: Bun.env['PORT'] || '3000',
+      default: process.env['PORT'] || '3000',
     },
     sw: {
       type: 'boolean',

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { exec } from 'node:child_process';
-import { cp, exists, rename } from 'node:fs/promises';
+import { cp, exists, rename, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -91,7 +91,7 @@ if (isInitializing) {
   const { stderr } = await execAsync(`cp -r ${originDirectory} ${targetDirectory}`);
 
   try {
-    await Bun.write(
+    await writeFile(
       path.join(targetDirectory, '.gitignore'),
       'node_modules\n.env\n.blade',
     );
@@ -122,12 +122,12 @@ if (isDeveloping) {
 }
 
 const projects = [process.cwd()];
-const tsConfig = Bun.file(path.join(process.cwd(), 'tsconfig.json'));
+const tsConfig = path.join(process.cwd(), 'tsconfig.json');
 
 // If a `tsconfig.json` file exists that contains a `references` field, we should include
 // files from the referenced projects as well.
-if (await tsConfig.exists()) {
-  const tsConfigContents = await tsConfig.json();
+if (await exists(tsConfig)) {
+  const tsConfigContents = await import(tsConfig);
   const { references } = tsConfigContents || {};
 
   if (references && Array.isArray(references) && references.length > 0) {

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -1,4 +1,4 @@
-import { exists } from 'node:fs/promises';
+import { exists, readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { compile } from '@mdx-js/mdx';
 import withToc from '@stefanprobst/rehype-extract-toc';
@@ -19,7 +19,7 @@ export const getClientReferenceLoader = (): esbuild.Plugin => ({
   name: 'Client Reference Loader',
   setup(build) {
     build.onLoad({ filter: /\.client.(js|jsx|ts|tsx)?$/ }, async (source) => {
-      let contents = await Bun.file(source.path).text();
+      let contents = await readFile(source.path, 'utf-8');
       const loader = path.extname(source.path).slice(1) as 'js' | 'jsx' | 'ts' | 'tsx';
 
       const transpiler = new Bun.Transpiler({ loader });
@@ -123,7 +123,7 @@ export const getMdxLoader = (
   name: 'MDX Loader',
   setup(build) {
     build.onLoad({ filter: /\.mdx$/ }, async (source) => {
-      const contents = await Bun.file(source.path).text();
+      const contents = await readFile(source.path, 'utf8');
 
       const yamlPattern = /^\s*---\s*\n([\s\S]*?)\n\s*---\s*/;
 
@@ -171,7 +171,7 @@ export const getReactAriaLoader = (): esbuild.Plugin => ({
 
         if (name === 'en-US') {
           return {
-            contents: await Bun.file(source.path).text(),
+            contents: await readFile(source.path),
             loader: 'js',
           };
         }

--- a/packages/blade/private/shell/utils/index.ts
+++ b/packages/blade/private/shell/utils/index.ts
@@ -1,4 +1,4 @@
-import { exists, readdir, rm, writeFile } from 'node:fs/promises';
+import { exists, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
   compile as compileTailwind,
@@ -249,9 +249,8 @@ export const prepareStyles = async (
     return projects.map((project) => path.join(project, directory));
   });
 
-  const inputFile = Bun.file(styleInputFile);
-  const input = (await inputFile.exists())
-    ? await inputFile.text()
+  const input = (await exists(styleInputFile))
+    ? await readFile(styleInputFile, 'utf8')
     : `@import 'tailwindcss';`;
 
   const compiler = await compileTailwind(input, {

--- a/packages/blade/private/shell/utils/index.ts
+++ b/packages/blade/private/shell/utils/index.ts
@@ -1,4 +1,4 @@
-import { exists, readdir, rm } from 'node:fs/promises';
+import { exists, readdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
   compile as compileTailwind,
@@ -272,5 +272,5 @@ export const prepareStyles = async (
   });
 
   const tailwindOutput = path.join(outputDirectory, getOutputFile(bundleId, 'css'));
-  await Bun.write(tailwindOutput, optimizedStyles.code);
+  await writeFile(tailwindOutput, optimizedStyles.code);
 };

--- a/packages/blade/private/shell/utils/index.ts
+++ b/packages/blade/private/shell/utils/index.ts
@@ -153,13 +153,13 @@ export const composeEnvironmentVariables = (options: {
 }): Record<string, string> => {
   const { provider, environment, isLoggingQueries, enableServiceWorker } = options;
 
-  const filteredVariables = Object.entries(Bun.env).filter(([key]) => {
+  const filteredVariables = Object.entries(process.env).filter(([key]) => {
     return key.startsWith('BLADE_');
   }) as Array<[string, string]>;
 
   const defined = Object.fromEntries(filteredVariables);
 
-  if (Bun.env['BLADE_ENV']) {
+  if (process.env['BLADE_ENV']) {
     let message = `${loggingPrefixes.error} The \`BLADE_ENV\` environment variable is provided by BLADE`;
     message += ` and cannot be overwritten. Using the \`blade\` command for "development"`;
     message += ` and \`blade build\` for "production" will automatically infer the value.`;
@@ -171,23 +171,23 @@ export const composeEnvironmentVariables = (options: {
   defined['__BLADE_SERVICE_WORKER'] = enableServiceWorker.toString();
 
   if (provider === 'cloudflare') {
-    defined['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['CF_PAGES_BRANCH'] ?? '';
-    defined['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['CF_PAGES_COMMIT_SHA'] ?? '';
+    defined['BLADE_PUBLIC_GIT_BRANCH'] = process.env['CF_PAGES_BRANCH'] ?? '';
+    defined['BLADE_PUBLIC_GIT_COMMIT'] = process.env['CF_PAGES_COMMIT_SHA'] ?? '';
   }
 
   if (provider === 'netlify') {
-    defined['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['BRANCH'] ?? '';
-    defined['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['COMMIT_REF'] ?? '';
+    defined['BLADE_PUBLIC_GIT_BRANCH'] = process.env['BRANCH'] ?? '';
+    defined['BLADE_PUBLIC_GIT_COMMIT'] = process.env['COMMIT_REF'] ?? '';
   }
 
   if (provider === 'vercel') {
-    defined['BLADE_PUBLIC_GIT_BRANCH'] = Bun.env['VERCEL_GIT_COMMIT_REF'] ?? '';
-    defined['BLADE_PUBLIC_GIT_COMMIT'] = Bun.env['VERCEL_GIT_COMMIT_SHA'] ?? '';
+    defined['BLADE_PUBLIC_GIT_BRANCH'] = process.env['VERCEL_GIT_COMMIT_REF'] ?? '';
+    defined['BLADE_PUBLIC_GIT_COMMIT'] = process.env['VERCEL_GIT_COMMIT_SHA'] ?? '';
   }
 
   defined['BLADE_DATA_WORKER'] ??= 'https://data.ronin.co';
   defined['BLADE_STORAGE_WORKER'] ??= 'https://storage.ronin.co';
-  defined['RONIN_TOKEN'] = Bun.env['RONIN_TOKEN'] ?? '';
+  defined['RONIN_TOKEN'] = process.env['RONIN_TOKEN'] ?? '';
 
   // Used by dependencies and the application itself to understand which environment the
   // application is currently running in.

--- a/packages/blade/private/shell/utils/providers.ts
+++ b/packages/blade/private/shell/utils/providers.ts
@@ -16,9 +16,9 @@ import type { DeploymentProvider } from '@/private/universal/types/util';
  * @returns A string representing the provider name.
  */
 export const getProvider = (): DeploymentProvider => {
-  if (Bun.env['WORKERS_CI']) return 'cloudflare';
-  if (Bun.env['NETLIFY']) return 'netlify';
-  if (Bun.env['VERCEL']) return 'vercel';
+  if (process.env['WORKERS_CI']) return 'cloudflare';
+  if (process.env['NETLIFY']) return 'netlify';
+  if (process.env['VERCEL']) return 'vercel';
   return defaultDeploymentProvider;
 };
 


### PR DESCRIPTION
This change replaces Bun-specific APIs with Node.js APIs where possible, to reduce our dependence on Bun.

This contributes to https://github.com/ronin-co/blade/issues/205.