### PR TITLE
Replaced `bun blade init` with `bun create blade`

### DIFF
--- a/docs/components/snippet.client.tsx
+++ b/docs/components/snippet.client.tsx
@@ -6,7 +6,7 @@ export const Snippet = () => {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
-    navigator.clipboard.writeText('bunx blade init');
+    navigator.clipboard.writeText('bun create blade');
     setCopied(true);
 
     setTimeout(() => setCopied(false), 1500);
@@ -39,7 +39,7 @@ export const Snippet = () => {
           </span>
         </span>
 
-        <span>bunx blade init</span>
+        <span>bun create blade</span>
       </span>
 
       <span

--- a/docs/pages/deploying.mdx
+++ b/docs/pages/deploying.mdx
@@ -144,4 +144,4 @@ EXPOSE 3000/tcp
 ENTRYPOINT [ "bun", "run", "serve" ]
 ```
 
-To deploy a Docker container, you could, for example, create a new account on [Fly](https://fly.io), then run `bunx blade init` to create a new [example app](https://github.com/ronin-co/blade/tree/main/packages/create-blade/templates/basic) with Blade, add the `Dockfile` to the directory, and lastly run `fly launch` to deploy your app. Fly will automatically detect the file and proceed with deploying your app.
+To deploy a Docker container, you could, for example, create a new account on [Fly](https://fly.io), then run `bun create blade` to create a new [example app](https://github.com/ronin-co/blade/tree/main/packages/create-blade/templates/basic) with Blade, add the `Dockfile` to the directory, and lastly run `fly launch` to deploy your app. Fly will automatically detect the file and proceed with deploying your app.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -72,7 +72,7 @@ Start building your first application with Blade by installing [Bun](https://bun
 Afterward, run the following command to create a new example application:
 
 ```bash
-bunx blade init
+bun create blade
 ```
 
 A new directory named `blade-example` will be created as a result, which contains your newly created application.

--- a/docs/pages/pages.mdx
+++ b/docs/pages/pages.mdx
@@ -238,7 +238,7 @@ Welcome to our documentation! This guide will help you get up and running quickl
 Install the package using your preferred package manager:
 
 ```bash
-bunx blade init
+bun create blade
 ```
 
 ## Conclusion

--- a/packages/blade/README.md
+++ b/packages/blade/README.md
@@ -41,7 +41,7 @@ To get started with Blade, first make sure you have [Bun](https://bun.sh) instal
 Next, create a new app with this command:
 
 ```bash
-bunx blade init
+bun create blade
 ```
 
 Afterward, enter the newly created directory and install the dependencies:


### PR DESCRIPTION
This change replaces all occurrences of `bun blade init` with the new `bun create blade` since that is our new recommended standard for scaffolding a new Blade project.

This closes #213.