### PR TITLE
Fixed init command copy message

### DIFF
--- a/docs/components/snippet.client.tsx
+++ b/docs/components/snippet.client.tsx
@@ -51,7 +51,7 @@ export const Snippet = () => {
           },
         )}>
         <Icons.Check className="size-4" />
-        <span>Copied to clipboard</span>
+        <span>Copied!</span>
       </span>
     </button>
   );


### PR DESCRIPTION
## What's changed?

Fixed the success/copy message within the `<Snippet />` component.

## Preview

### Before

![CleanShot 2025-06-25 at 14 20 37@2x](https://github.com/user-attachments/assets/a9f17cf2-8174-4f7e-a8ae-7092ab35c0da)

### After

![CleanShot 2025-06-25 at 14 21 30@2x](https://github.com/user-attachments/assets/fbd15981-9835-4504-a689-b382913618a1)
