### PR TITLE
Correctly load client bundles

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -85,7 +85,8 @@
         "useForOf": "off",
         "noArguments": "off",
         "noNamespaceImport": "off",
-        "noNamespace": "off"
+        "noNamespace": "off",
+        "noImplicitBoolean": "off"
       },
       "suspicious": {
         "all": true,

--- a/packages/blade/private/server/components/root.tsx
+++ b/packages/blade/private/server/components/root.tsx
@@ -85,7 +85,7 @@ const Root = ({ children, serverContext }: RootProps) => {
                     key={source}
                     type="module"
                     className="blade-script"
-                    async={true}
+                    async
                   />
                 );
               case 'worker':

--- a/packages/blade/private/server/components/root.tsx
+++ b/packages/blade/private/server/components/root.tsx
@@ -85,7 +85,7 @@ const Root = ({ children, serverContext }: RootProps) => {
                     key={source}
                     type="module"
                     className="blade-script"
-                    // Don't block the parsing of the remaining HTML.
+                    // Don't block the parsing of the remaining HTML, CSS, etc.
                     async
                   />
                 );

--- a/packages/blade/private/server/components/root.tsx
+++ b/packages/blade/private/server/components/root.tsx
@@ -85,6 +85,7 @@ const Root = ({ children, serverContext }: RootProps) => {
                     key={source}
                     type="module"
                     className="blade-script"
+                    // Don't block the parsing of the remaining HTML.
                     async
                   />
                 );

--- a/packages/blade/private/server/components/root.tsx
+++ b/packages/blade/private/server/components/root.tsx
@@ -85,6 +85,7 @@ const Root = ({ children, serverContext }: RootProps) => {
                     key={source}
                     type="module"
                     className="blade-script"
+                    async={true}
                   />
                 );
               case 'worker':


### PR DESCRIPTION
This change ensures that the JavaScript bundles on the client don't block the rest of the document.