### PR TITLE
Ensure latest package version for docs

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -10,7 +10,7 @@
         "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-tooltip": "1.2.7",
         "@tabler/icons-react": "3.34.0",
-        "blade": "3.4.4",
+        "blade": "3.4.6",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "lucide-react": "0.513.0",
@@ -316,7 +316,7 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "blade": ["blade@3.4.4", "", { "dependencies": { "@hono/node-ws": "1.2.0", "@ronin/compiler": "0.18.9", "@ronin/react": "0.1.4", "@ronin/syntax": "0.2.43", "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "@typescript-eslint/typescript-estree": "8.35.0", "dotenv": "16.5.0", "esbuild": "0.25.5", "gradient-string": "3.0.0", "ronin": "6.7.4" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-5i1nUCvmwf+bEh7Aw3+TSLuvrZ3HI0e4aUPqowDy2LLgxiEtF5cJqBAqoL1l5y8BND9G+0X+S2usoXs37CK5FQ=="],
+    "blade": ["blade@3.4.6", "", { "dependencies": { "@hono/node-ws": "1.2.0", "@ronin/compiler": "0.18.9", "@ronin/react": "0.1.4", "@ronin/syntax": "0.2.43", "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "@typescript-eslint/typescript-estree": "8.35.0", "dotenv": "16.5.0", "esbuild": "0.25.5", "gradient-string": "3.0.0", "ronin": "6.7.4" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-uR4fXLnMlZta2Iwf/rbHTl0D5GZ93P1PXqlWTe9OqeFBRDC2hcA3lrx8VpipGqJp94kpx5xURFxcU4H/1xhjcg=="],
 
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-separator": "1.1.7",
     "@radix-ui/react-slot": "1.2.3",
     "@radix-ui/react-tooltip": "1.2.7",
-    "blade": "3.4.4",
+    "blade": "3.4.6",
     "@tabler/icons-react": "3.34.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",


### PR DESCRIPTION
This change upgrades the version of `blade` used by our docs to version `3.4.6`.