### PR TITLE
Implement error modal and enhance build error handling

### DIFF
--- a/packages/blade/private/client/components/blade-overlay.tsx
+++ b/packages/blade/private/client/components/blade-overlay.tsx
@@ -7,38 +7,59 @@ import { ErrorModal } from '@/private/client/components/error-modal';
 import type { StateMessage } from '@/private/universal/utils/state-msg';
 import type BuildError from '@/private/universal/utils/build-error';
 
-interface ErrorBadgeProps {
-  count: number;
-}
+// interface ErrorBadgeProps {
+//   count: number;
+// }
 
-const ErrorBadge = ({ count }: ErrorBadgeProps) => {
-  if (count === 0) return null;
+// const ErrorBadge = ({ count }: ErrorBadgeProps) => {
+//   if (count === 0) return null;
 
-  return (
-    <div
-      style={{
-        position: 'fixed',
-        bottom: '1rem',
-        left: '4.5rem',
-        backgroundColor: 'red',
-        color: 'white',
-        borderRadius: '50%',
-        width: '1.5rem',
-        height: '1.5rem',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        fontSize: '0.75rem',
-        fontWeight: 'bold',
-        zIndex: 51,
-      }}>
-      {count}
-    </div>
-  );
-};
+//   return (
+//     <div
+//       style={{
+//         position: 'fixed',
+//         bottom: '1rem',
+//         left: '4.5rem',
+//         backgroundColor: 'red',
+//         color: 'white',
+//         borderRadius: '50%',
+//         width: '1.5rem',
+//         height: '1.5rem',
+//         display: 'flex',
+//         alignItems: 'center',
+//         justifyContent: 'center',
+//         fontSize: '0.75rem',
+//         fontWeight: 'bold',
+//         zIndex: 51,
+//       }}>
+//       {count}
+//     </div>
+//   );
+// };
 
-const Floating = () => {
-  const { showModal } = useErrorModal();
+// const Floating = () => {
+
+//   return (
+//     <div
+//       style={{
+//         position: 'fixed',
+//         bottom: '1rem',
+//         left: '1rem',
+//         width: '3rem',
+//         height: '3rem',
+//         backgroundColor: 'black',
+//         borderRadius: '50%',
+//         boxShadow:
+//           '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+//         zIndex: 50,
+//         cursor: 'pointer',
+//       }}
+//     />
+//   );
+// };
+
+const BladeOverlay = () => {
+  const { isVisible, showModal } = useErrorModal();
 
   useEffect(() => {
     // Here we default to the origin available in the browser, because BLADE might
@@ -97,29 +118,7 @@ ${errorMessage.location.suggestion ? `Suggestion: ${errorMessage.location.sugges
 
     connect();
     return () => ws.close();
-  }, []);
-
-  return (
-    <div
-      style={{
-        position: 'fixed',
-        bottom: '1rem',
-        left: '1rem',
-        width: '3rem',
-        height: '3rem',
-        backgroundColor: 'black',
-        borderRadius: '50%',
-        boxShadow:
-          '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
-        zIndex: 50,
-        cursor: 'pointer',
-      }}
-    />
-  );
-};
-
-const BladeOverlay = () => {
-  const { isVisible } = useErrorModal();
+  }, [showModal]);
 
   if (!IS_CLIENT_DEV) return <></>;
 

--- a/packages/blade/private/client/components/blade-overlay.tsx
+++ b/packages/blade/private/client/components/blade-overlay.tsx
@@ -11,33 +11,31 @@ interface ErrorBadgeProps {
   count: number;
 }
 
-
-
 const ErrorBadge = ({ count }: ErrorBadgeProps) => {
   if (count === 0) return null;
 
   return (
-    <div style={{
-      position: 'fixed',
-      bottom: '1rem',
-      left: '4.5rem',
-      backgroundColor: 'red',
-      color: 'white',
-      borderRadius: '50%',
-      width: '1.5rem',
-      height: '1.5rem',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      fontSize: '0.75rem',
-      fontWeight: 'bold',
-      zIndex: 51
-    }}>
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '1rem',
+        left: '4.5rem',
+        backgroundColor: 'red',
+        color: 'white',
+        borderRadius: '50%',
+        width: '1.5rem',
+        height: '1.5rem',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '0.75rem',
+        fontWeight: 'bold',
+        zIndex: 51,
+      }}>
       {count}
     </div>
   );
-}
-
+};
 
 const Floating = () => {
   const { showModal } = useErrorModal();
@@ -60,7 +58,7 @@ const Floating = () => {
       switch (event.type) {
         case 'build-error':
           console.log(event);
-          const errorMessages: BuildError[] = JSON.parse(event.message)
+          const errorMessages: BuildError[] = JSON.parse(event.message);
           /**
            * TODO: Make the Modal able to show multiple error messages
            */
@@ -76,8 +74,7 @@ ${errorMessage.location.suggestion ? `Suggestion: ${errorMessage.location.sugges
           console.log('unsupported');
           break;
       }
-    }
-
+    };
 
     let ws: WebSocket;
 
@@ -96,12 +93,11 @@ ${errorMessage.location.suggestion ? `Suggestion: ${errorMessage.location.sugges
         const data = JSON.parse(event.data) as StateMessage;
         stateHandler(data);
       });
-
     };
 
     connect();
     return () => ws.close();
-  }, [])
+  }, []);
 
   return (
     <div
@@ -113,13 +109,14 @@ ${errorMessage.location.suggestion ? `Suggestion: ${errorMessage.location.sugges
         height: '3rem',
         backgroundColor: 'black',
         borderRadius: '50%',
-        boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+        boxShadow:
+          '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
         zIndex: 50,
-        cursor: 'pointer'
+        cursor: 'pointer',
       }}
     />
-  )
-}
+  );
+};
 
 const BladeOverlay = () => {
   const { isVisible } = useErrorModal();
@@ -135,7 +132,7 @@ const BladeOverlay = () => {
       </div>
     </>
   );
-}
+};
 
 const WrappedBladeOverlay = () => (
   <ErrorModalProvider>

--- a/packages/blade/private/client/components/blade-overlay.tsx
+++ b/packages/blade/private/client/components/blade-overlay.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import { wrapClientComponent } from '../utils/wrap-client';
 
 interface ErrorBadgeProps{
@@ -29,21 +28,9 @@ const ErrorBadge = ({ count }: ErrorBadgeProps) => {
   );
 }
 
-
-const BladeOverlay = () => {
-  const [count, setCount] = useState(0);
-
-  const handleClick = () => {
-    setCount(prev => prev + 1);
-  };
-
+const Floating = () => {
   return (
-    <div style={{ display: 'flex', flexDirection: 'row' }}>
-      <ErrorBadge count={count} />
-      
-      {/* Circle */}
-      <div 
-        onClick={handleClick}
+     <div 
         style={{
           position: 'fixed',
           bottom: '1rem',
@@ -57,6 +44,16 @@ const BladeOverlay = () => {
           cursor: 'pointer'
         }}
       />
+  )
+}
+
+const BladeOverlay = () => {
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'row' }}>
+      <ErrorBadge count={0} />
+      <Floating />
+      
     </div>
   );
 }

--- a/packages/blade/private/client/components/blade-overlay.tsx
+++ b/packages/blade/private/client/components/blade-overlay.tsx
@@ -58,6 +58,10 @@ import type BuildError from '@/private/universal/utils/build-error';
 //   );
 // };
 
+/**
+ * BladeOverlay is a bubble indicator component used to display
+ * visual notifications for build errors, client errors, and other statuses.
+ */
 const BladeOverlay = () => {
   const { isVisible, showModal } = useErrorModal();
 
@@ -66,6 +70,9 @@ const BladeOverlay = () => {
     // locally sit behind a proxy that terminates TLS, in which case the origin protocol
     // would be `http` if we make use of the location provided by `usePrivateLocation`,
     // since that comes from the server.
+
+    // This endpoint can be used to send multiple stages of statuses like build-pending to indicate
+    // it's in a build process, or failures in server, etc.
     const url = new URL('/_blade/state', window.location.origin);
 
     // This also replaces `https` with `wss` automatically.

--- a/packages/blade/private/client/components/blade-overlay.tsx
+++ b/packages/blade/private/client/components/blade-overlay.tsx
@@ -1,11 +1,21 @@
-import { wrapClientComponent } from '../utils/wrap-client';
+import { IS_CLIENT_DEV } from '@/private/client/utils/constants';
+import { wrapClientComponent } from '@/private/client/utils/wrap-client';
+import { useEffect } from 'react';
+import { ErrorModalProvider } from '@/private/client/contexts/error-modal';
+import { useErrorModal } from '@/private/client/hooks/error-modal';
+import { ErrorModal } from '@/private/client/components/error-modal';
+import type { StateMessage } from '@/private/universal/utils/state-msg';
+import type BuildError from '@/private/universal/utils/build-error';
 
-interface ErrorBadgeProps{
-    count: number;
-} 
+interface ErrorBadgeProps {
+  count: number;
+}
+
+
+
 const ErrorBadge = ({ count }: ErrorBadgeProps) => {
   if (count === 0) return null;
-  
+
   return (
     <div style={{
       position: 'fixed',
@@ -28,36 +38,111 @@ const ErrorBadge = ({ count }: ErrorBadgeProps) => {
   );
 }
 
+
 const Floating = () => {
+  const { showModal } = useErrorModal();
+
+  useEffect(() => {
+    // Here we default to the origin available in the browser, because BLADE might
+    // locally sit behind a proxy that terminates TLS, in which case the origin protocol
+    // would be `http` if we make use of the location provided by `usePrivateLocation`,
+    // since that comes from the server.
+    const url = new URL('/_blade/state', window.location.origin);
+
+    // This also replaces `https` with `wss` automatically.
+    url.protocol = url.protocol.replace('http', 'ws');
+
+    /**
+     * TODO: This WebSocket state handler logic should be moved to a dedicated
+     * service or hook for better organization and reusability
+     */
+    const stateHandler = (event: StateMessage) => {
+      switch (event.type) {
+        case 'build-error':
+          console.log(event);
+          const errorMessages: BuildError[] = JSON.parse(event.message)
+          /**
+           * TODO: Make the Modal able to show multiple error messages
+           */
+          const errorMessage = errorMessages[0];
+          const richErrorMessage = `
+Error message: ${errorMessage.errorMessage}
+File ${errorMessage.location.file} Line ${errorMessage.location.line}: ${errorMessage.location.text}
+${errorMessage.location.suggestion ? `Suggestion: ${errorMessage.location.suggestion}` : ''}
+`.trim();
+          showModal('Build Error', richErrorMessage);
+          break;
+        default:
+          console.log('unsupported');
+          break;
+      }
+    }
+
+
+    let ws: WebSocket;
+
+    const connect = () => {
+      // Close the old connection if there is one available.
+      if (ws) ws.close();
+
+      // Establish a new connection.
+      ws = new WebSocket(url.href);
+
+      // If the connection was closed unexpectedly, try to reconnect.
+      ws.addEventListener('error', () => connect(), { once: true });
+
+      // Add listener to state events
+      ws.addEventListener('message', (event: MessageEvent) => {
+        const data = JSON.parse(event.data) as StateMessage;
+        stateHandler(data);
+      });
+
+    };
+
+    connect();
+    return () => ws.close();
+  }, [])
+
   return (
-     <div 
-        style={{
-          position: 'fixed',
-          bottom: '1rem',
-          left: '1rem',
-          width: '3rem',
-          height: '3rem',
-          backgroundColor: 'black',
-          borderRadius: '50%',
-          boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
-          zIndex: 50,
-          cursor: 'pointer'
-        }}
-      />
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '1rem',
+        left: '1rem',
+        width: '3rem',
+        height: '3rem',
+        backgroundColor: 'black',
+        borderRadius: '50%',
+        boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+        zIndex: 50,
+        cursor: 'pointer'
+      }}
+    />
   )
 }
 
 const BladeOverlay = () => {
+  const { isVisible } = useErrorModal();
+
+  if (!IS_CLIENT_DEV) return <></>;
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'row' }}>
-      <ErrorBadge count={0} />
-      <Floating />
-      
-    </div>
+    <>
+      {isVisible && <ErrorModal />}
+      <div style={{ display: 'flex', flexDirection: 'row' }}>
+        <ErrorBadge count={0} />
+        <Floating />
+      </div>
+    </>
   );
 }
 
-wrapClientComponent(BladeOverlay, 'BladeOverlay');
+const WrappedBladeOverlay = () => (
+  <ErrorModalProvider>
+    <BladeOverlay />
+  </ErrorModalProvider>
+);
 
-export { BladeOverlay };
+wrapClientComponent(WrappedBladeOverlay, 'BladeOverlay');
+
+export { WrappedBladeOverlay as BladeOverlay };

--- a/packages/blade/private/client/components/blade-overlay.tsx
+++ b/packages/blade/private/client/components/blade-overlay.tsx
@@ -126,10 +126,14 @@ const BladeOverlay = () => {
   return (
     <>
       {isVisible && <ErrorModal />}
-      <div style={{ display: 'flex', flexDirection: 'row' }}>
+      {/*
+       * I made this hidden now because there is no actual usage for it right now, but it's a base foundation
+       * for both client errors and server errors to be shown here or even more like changing configs etc..
+       */}
+      {/* <div style={{ display: 'flex', flexDirection: 'row' }}>
         <ErrorBadge count={0} />
         <Floating />
-      </div>
+      </div> */}
     </>
   );
 };

--- a/packages/blade/private/client/components/blade-overlay.tsx
+++ b/packages/blade/private/client/components/blade-overlay.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { wrapClientComponent } from '../utils/wrap-client';
+
+interface ErrorBadgeProps{
+    count: number;
+} 
+const ErrorBadge = ({ count }: ErrorBadgeProps) => {
+  if (count === 0) return null;
+  
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: '1rem',
+      left: '4.5rem',
+      backgroundColor: 'red',
+      color: 'white',
+      borderRadius: '50%',
+      width: '1.5rem',
+      height: '1.5rem',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      fontSize: '0.75rem',
+      fontWeight: 'bold',
+      zIndex: 51
+    }}>
+      {count}
+    </div>
+  );
+}
+
+
+const BladeOverlay = () => {
+  const [count, setCount] = useState(0);
+
+  const handleClick = () => {
+    setCount(prev => prev + 1);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'row' }}>
+      <ErrorBadge count={count} />
+      
+      {/* Circle */}
+      <div 
+        onClick={handleClick}
+        style={{
+          position: 'fixed',
+          bottom: '1rem',
+          left: '1rem',
+          width: '3rem',
+          height: '3rem',
+          backgroundColor: 'black',
+          borderRadius: '50%',
+          boxShadow: '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)',
+          zIndex: 50,
+          cursor: 'pointer'
+        }}
+      />
+    </div>
+  );
+}
+
+wrapClientComponent(BladeOverlay, 'BladeOverlay');
+
+export { BladeOverlay };

--- a/packages/blade/private/client/components/error-modal.tsx
+++ b/packages/blade/private/client/components/error-modal.tsx
@@ -1,0 +1,100 @@
+import { useErrorModal } from '@/private/client/hooks/error-modal';
+import { wrapClientComponent } from '@/private/client/utils/wrap-client';
+
+const ErrorModal = () => {
+  const { title, message, hideModal } = useErrorModal();
+
+  return (
+    <div 
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        backgroundColor: 'rgba(0, 0, 0, 0.95)',
+        backdropFilter: 'blur(4px)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        zIndex: 9999
+      }}
+      onClick={hideModal}
+    >
+      <div 
+        style={{
+          position: 'relative',
+          width: '90%',
+          maxWidth: '600px',
+          backgroundColor: '#0A0A0A',
+          border: '2px solid #333',
+          borderRadius: '12px',
+          padding: '2rem',
+          boxShadow: '0 0 30px rgba(255, 0, 0, 0.3), 0 0 60px rgba(255, 0, 0, 0.15)',
+          animation: 'pulse 2s ease-in-out infinite alternate'
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Error Content */}
+        <div style={{ color: '#fff', textAlign: 'center' }}>
+          <h2 style={{ 
+            margin: '0 0 1rem 0', 
+            fontSize: '1.5rem', 
+            fontWeight: 'bold',
+            color: '#ff4444'
+          }}>
+            {title}
+          </h2>
+          
+          <div style={{
+            backgroundColor: '#000',
+            border: '1px solid #444',
+            borderRadius: '6px',
+            padding: '1rem',
+            marginBottom: '1rem',
+            fontFamily: 'monospace',
+            fontSize: '0.875rem',
+            textAlign: 'left',
+            overflow: 'auto',
+            maxHeight: '300px',
+            whiteSpace: 'pre-wrap'
+          }}>
+            {message}
+          </div>
+          
+          <div style={{
+            display: 'flex',
+            gap: '1rem',
+            justifyContent: 'center'
+          }}>
+            <button 
+              style={{
+                backgroundColor: '#333',
+                color: '#fff',
+                border: '1px solid #555',
+                borderRadius: '4px',
+                padding: '0.5rem 1rem',
+                cursor: 'pointer',
+                fontSize: '0.875rem'
+              }}
+              onClick={hideModal}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+      
+      <style>{`
+        @keyframes pulse {
+          0% { box-shadow: 0 0 30px rgba(255, 0, 0, 0.3), 0 0 60px rgba(255, 0, 0, 0.15); }
+          100% { box-shadow: 0 0 40px rgba(255, 0, 0, 0.5), 0 0 80px rgba(255, 0, 0, 0.25); }
+        }
+      `}</style>
+    </div>
+  );
+};
+
+wrapClientComponent(ErrorModal, 'ErrorModal');
+
+export { ErrorModal };

--- a/packages/blade/private/client/components/error-modal.tsx
+++ b/packages/blade/private/client/components/error-modal.tsx
@@ -5,7 +5,7 @@ const ErrorModal = () => {
   const { title, message, hideModal } = useErrorModal();
 
   return (
-    <div 
+    <div
       style={{
         position: 'fixed',
         top: 0,
@@ -17,11 +17,10 @@ const ErrorModal = () => {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        zIndex: 9999
+        zIndex: 9999,
       }}
-      onClick={hideModal}
-    >
-      <div 
+      onClick={hideModal}>
+      <div
         style={{
           position: 'relative',
           width: '90%',
@@ -31,43 +30,45 @@ const ErrorModal = () => {
           borderRadius: '12px',
           padding: '2rem',
           boxShadow: '0 0 30px rgba(255, 0, 0, 0.3), 0 0 60px rgba(255, 0, 0, 0.15)',
-          animation: 'pulse 2s ease-in-out infinite alternate'
+          animation: 'pulse 2s ease-in-out infinite alternate',
         }}
-        onClick={(e) => e.stopPropagation()}
-      >
+        onClick={(e) => e.stopPropagation()}>
         {/* Error Content */}
         <div style={{ color: '#fff', textAlign: 'center' }}>
-          <h2 style={{ 
-            margin: '0 0 1rem 0', 
-            fontSize: '1.5rem', 
-            fontWeight: 'bold',
-            color: '#ff4444'
-          }}>
+          <h2
+            style={{
+              margin: '0 0 1rem 0',
+              fontSize: '1.5rem',
+              fontWeight: 'bold',
+              color: '#ff4444',
+            }}>
             {title}
           </h2>
-          
-          <div style={{
-            backgroundColor: '#000',
-            border: '1px solid #444',
-            borderRadius: '6px',
-            padding: '1rem',
-            marginBottom: '1rem',
-            fontFamily: 'monospace',
-            fontSize: '0.875rem',
-            textAlign: 'left',
-            overflow: 'auto',
-            maxHeight: '300px',
-            whiteSpace: 'pre-wrap'
-          }}>
+
+          <div
+            style={{
+              backgroundColor: '#000',
+              border: '1px solid #444',
+              borderRadius: '6px',
+              padding: '1rem',
+              marginBottom: '1rem',
+              fontFamily: 'monospace',
+              fontSize: '0.875rem',
+              textAlign: 'left',
+              overflow: 'auto',
+              maxHeight: '300px',
+              whiteSpace: 'pre-wrap',
+            }}>
             {message}
           </div>
-          
-          <div style={{
-            display: 'flex',
-            gap: '1rem',
-            justifyContent: 'center'
-          }}>
-            <button 
+
+          <div
+            style={{
+              display: 'flex',
+              gap: '1rem',
+              justifyContent: 'center',
+            }}>
+            <button
               style={{
                 backgroundColor: '#333',
                 color: '#fff',
@@ -75,16 +76,15 @@ const ErrorModal = () => {
                 borderRadius: '4px',
                 padding: '0.5rem 1rem',
                 cursor: 'pointer',
-                fontSize: '0.875rem'
+                fontSize: '0.875rem',
               }}
-              onClick={hideModal}
-            >
+              onClick={hideModal}>
               Close
             </button>
           </div>
         </div>
       </div>
-      
+
       <style>{`
         @keyframes pulse {
           0% { box-shadow: 0 0 30px rgba(255, 0, 0, 0.3), 0 0 60px rgba(255, 0, 0, 0.15); }

--- a/packages/blade/private/client/contexts/error-modal.tsx
+++ b/packages/blade/private/client/contexts/error-modal.tsx
@@ -32,13 +32,14 @@ const ErrorModalProvider = ({ children }: ErrorModalProviderProps) => {
   };
 
   return (
-    <ErrorModalContext.Provider value={{
-      isVisible,
-      title,
-      message,
-      showModal,
-      hideModal
-    }}>
+    <ErrorModalContext.Provider
+      value={{
+        isVisible,
+        title,
+        message,
+        showModal,
+        hideModal,
+      }}>
       {children}
     </ErrorModalContext.Provider>
   );

--- a/packages/blade/private/client/contexts/error-modal.tsx
+++ b/packages/blade/private/client/contexts/error-modal.tsx
@@ -1,0 +1,48 @@
+import { createContext, useState } from 'react';
+import type { ReactNode } from 'react';
+
+// Error Modal Context
+interface ErrorModalState {
+  isVisible: boolean;
+  title: string;
+  message: string;
+  showModal: (title: string, message: string) => void;
+  hideModal: () => void;
+}
+
+const ErrorModalContext = createContext<ErrorModalState | null>(null);
+
+interface ErrorModalProviderProps {
+  children: ReactNode;
+}
+
+const ErrorModalProvider = ({ children }: ErrorModalProviderProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [title, setTitle] = useState('');
+  const [message, setMessage] = useState('');
+
+  const showModal = (newTitle: string, newMessage: string) => {
+    setTitle(newTitle);
+    setMessage(newMessage);
+    setIsVisible(true);
+  };
+
+  const hideModal = () => {
+    setIsVisible(false);
+  };
+
+  return (
+    <ErrorModalContext.Provider value={{
+      isVisible,
+      title,
+      message,
+      showModal,
+      hideModal
+    }}>
+      {children}
+    </ErrorModalContext.Provider>
+  );
+};
+
+export { ErrorModalProvider, ErrorModalContext };
+export type { ErrorModalState };

--- a/packages/blade/private/client/hooks/error-modal.tsx
+++ b/packages/blade/private/client/hooks/error-modal.tsx
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { ErrorModalContext } from '@/private/client/contexts/error-modal';
+import type { ErrorModalState } from '@/private/client/contexts/error-modal';
+
+const useErrorModal = (): ErrorModalState => {
+  const context = useContext(ErrorModalContext);
+  if (!context) {
+    throw new Error('useErrorModal must be used within an ErrorModalProvider');
+  }
+  return context;
+};
+
+export { useErrorModal };

--- a/packages/blade/private/client/index.ts
+++ b/packages/blade/private/client/index.ts
@@ -3,6 +3,7 @@ import { hydrateRoot } from 'react-dom/client';
 
 import '@/private/client/components/history';
 import '@/private/client/components/blade-overlay';
+import '@/private/client/components/error-modal';
 import '@/public/client/components';
 import fetchPage from '@/private/client/utils/fetch-page';
 

--- a/packages/blade/private/client/index.ts
+++ b/packages/blade/private/client/index.ts
@@ -2,6 +2,7 @@ import 'client-list';
 import { hydrateRoot } from 'react-dom/client';
 
 import '@/private/client/components/history';
+import '@/private/client/components/blade-overlay';
 import '@/public/client/components';
 import fetchPage from '@/private/client/utils/fetch-page';
 

--- a/packages/blade/private/server/components/root.tsx
+++ b/packages/blade/private/server/components/root.tsx
@@ -3,6 +3,7 @@ import { flatten } from 'flat';
 import type { ReactNode } from 'react';
 
 import { History } from '@/private/client/components/history';
+import { BladeOverlay } from '@/private/client/components/blade-overlay';
 import { composeWorkerRegistration } from '@/private/client/utils/service-worker';
 import { RootServerContext, type ServerContext } from '@/private/server/context';
 import type { PageMetadata, RecursiveRequired, ValueOf } from '@/private/server/types';
@@ -191,6 +192,7 @@ const Root = ({ children, serverContext }: RootProps) => {
       <body
         suppressHydrationWarning={true}
         className={metadata.bodyClassName}>
+        <BladeOverlay />
         <RootServerContext.Provider value={serverContext}>
           <History universalContext={getSerializableContext(serverContext)}>
             {children}

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -212,7 +212,7 @@ if (isBuilding || isDeveloping) {
               // Revalidate the client.
               if (server.reloadChannel) server.reloadChannel.send('revalidate');
             } else {
-              // Parse build error
+              // Transform esbuild errors into a standardized format for client display
               const mappedError = result.errors.map((error) => {
                 const location = {
                   file: error.location?.file,

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -212,7 +212,6 @@ if (isBuilding || isDeveloping) {
               // Revalidate the client.
               if (server.reloadChannel) server.reloadChannel.send('revalidate');
             } else {
-
               // Parse build error
               const mappedError = result.errors.map((error) => {
                 const location = {
@@ -229,7 +228,10 @@ if (isBuilding || isDeveloping) {
               });
 
               // Broadcast error state to client
-              if (server.stateChannel) server.stateChannel.send(createStateMessage('build-error', JSON.stringify(mappedError)));
+              if (server.stateChannel)
+                server.stateChannel.send(
+                  createStateMessage('build-error', JSON.stringify(mappedError)),
+                );
             }
           });
         },

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -209,6 +209,9 @@ if (isBuilding || isDeveloping) {
 
               // Revalidate the client.
               if (server.channel) server.channel.send('revalidate');
+            }else{
+               // Broadcast error to client
+               if (server.channel) server.channel.send(`error:${JSON.stringify(result.errors)}`);
             }
           });
         },
@@ -257,7 +260,12 @@ if (isBuilding || isDeveloping) {
         const relativePath = path.relative(process.cwd(), eventPath);
 
         spinner = logSpinner(`${eventMessage}, rebuilding: ${relativePath}`);
-        mainBuild.rebuild();
+        
+        mainBuild.rebuild().catch(()=>{
+          console.log(`\n${loggingPrefixes.info} ✘ Build failed! Please check the following errors\n`);
+          spinner.fail()
+          spinner.stop()
+        });
       });
   } else {
     // Stop the build context.

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -208,10 +208,11 @@ if (isBuilding || isDeveloping) {
               server.module = import(path.join(outputDirectory, moduleName));
 
               // Revalidate the client.
-              if (server.channel) server.channel.send('revalidate');
-            }else{
-               // Broadcast error to client
-               if (server.channel) server.channel.send(`error:${JSON.stringify(result.errors)}`);
+              if (server.reloadChannel) server.reloadChannel.send('revalidate');
+            } else {
+              // Broadcast error to client
+              if (server.stateChannel)
+                server.stateChannel.send(`error:${JSON.stringify(result.errors)}`);
             }
           });
         },
@@ -260,11 +261,13 @@ if (isBuilding || isDeveloping) {
         const relativePath = path.relative(process.cwd(), eventPath);
 
         spinner = logSpinner(`${eventMessage}, rebuilding: ${relativePath}`);
-        
-        mainBuild.rebuild().catch(()=>{
-          console.log(`\n${loggingPrefixes.info} ✘ Build failed! Please check the following errors\n`);
-          spinner.fail()
-          spinner.stop()
+
+        mainBuild.rebuild().catch(() => {
+          console.log(
+            `\n${loggingPrefixes.info} ✘ Build failed! Please check the following errors\n`,
+          );
+          spinner.fail();
+          spinner.stop();
         });
       });
   } else {

--- a/packages/blade/private/shell/listener.ts
+++ b/packages/blade/private/shell/listener.ts
@@ -46,6 +46,8 @@ export const serve = async (
     })),
   );
 
+  // This endpoint can be used to send multiple stages of statuses like build-pending to indicate
+  // it's in a build process, or failures in server, etc.
   app.get(
     '/_blade/state',
     upgradeWebSocket(() => ({

--- a/packages/blade/private/shell/listener.ts
+++ b/packages/blade/private/shell/listener.ts
@@ -15,7 +15,8 @@ import { CLIENT_ASSET_PREFIX } from '@/private/universal/utils/constants';
 
 export interface ServerState {
   module?: Promise<{ default: Hono }>;
-  channel?: WSContext;
+  reloadChannel?: WSContext;
+  stateChannel?: WSContext;
 }
 
 export const serve = async (
@@ -41,7 +42,14 @@ export const serve = async (
   app.get(
     '/_blade/reload',
     upgradeWebSocket(() => ({
-      onOpen: (_event, channel) => (serverState.channel = channel),
+      onOpen: (_event, channel) => (serverState.reloadChannel = channel),
+    })),
+  );
+
+  app.get(
+    '/_blade/state',
+    upgradeWebSocket(() => ({
+      onOpen: (_event, channel) => (serverState.stateChannel = channel),
     })),
   );
 

--- a/packages/blade/private/universal/utils/build-error.ts
+++ b/packages/blade/private/universal/utils/build-error.ts
@@ -1,0 +1,9 @@
+export default interface BuildError{
+    location: {
+        file: string;
+        text: string;
+        line: number;
+        suggestion: string;
+    }
+    errorMessage: string;
+}

--- a/packages/blade/private/universal/utils/build-error.ts
+++ b/packages/blade/private/universal/utils/build-error.ts
@@ -1,9 +1,9 @@
-export default interface BuildError{
-    location: {
-        file: string;
-        text: string;
-        line: number;
-        suggestion: string;
-    }
-    errorMessage: string;
+export default interface BuildError {
+  location: {
+    file: string;
+    text: string;
+    line: number;
+    suggestion: string;
+  };
+  errorMessage: string;
 }

--- a/packages/blade/private/universal/utils/state-msg.ts
+++ b/packages/blade/private/universal/utils/state-msg.ts
@@ -1,14 +1,14 @@
 export type StateType = 'build-error';
 
 export interface StateMessage {
-    type: StateType;
-    message: string;
+  type: StateType;
+  message: string;
 }
 
-export function createStateMessage(type: StateType, message: string){
-    let stateMessage: StateMessage = {
-        type,
-        message
-    }
-    return JSON.stringify(stateMessage)
+export function createStateMessage(type: StateType, message: string) {
+  let stateMessage: StateMessage = {
+    type,
+    message,
+  };
+  return JSON.stringify(stateMessage);
 }

--- a/packages/blade/private/universal/utils/state-msg.ts
+++ b/packages/blade/private/universal/utils/state-msg.ts
@@ -1,0 +1,14 @@
+export type StateType = 'build-error';
+
+export interface StateMessage {
+    type: StateType;
+    message: string;
+}
+
+export function createStateMessage(type: StateType, message: string){
+    let stateMessage: StateMessage = {
+        type,
+        message
+    }
+    return JSON.stringify(stateMessage)
+}


### PR DESCRIPTION
This PR introduces a foundational error modal component that gracefully displays build error messages in the frontend during development. It also adds a basic dev indicator bubble overlay, currently disabled as a placeholder for future enhancements.

Key changes include:
- Handles build errors on the server to prevent crashes and forward error messages to the frontend via WebSocket for display in a client-side modal (see demo GIF below).

- Implements a new WebSocket endpoint `/_blade/state` for streaming build and state updates from server to client

![preview](https://github.com/user-attachments/assets/5e283b7b-a32c-4beb-909f-cd2b3bee10a0)

This improves developer experience by providing real-time feedback on build issues without interrupting the dev server workflow.