### PR TITLE
Prevent crash for missing env vars

### DIFF
--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -215,6 +215,8 @@ if (isBuilding || isDeveloping) {
       },
     ],
     banner: {
+      // Prevent a crash for missing environment variables by ensuring that
+      // `import.meta.env` is defined.
       js: 'if(!import.meta.env){import.meta.env={}};',
     },
     define: composeEnvironmentVariables({


### PR DESCRIPTION
This change ensures that Blade doesn't crash if an environment variable of an app is not defined.