### PR TITLE
Disable Node.js compat for Cloudflare

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/blade": {
       "name": "blade",
-      "version": "3.4.7",
+      "version": "3.4.10",
       "bin": {
         "blade": "./dist/private/shell/index.js",
       },
@@ -27,7 +27,7 @@
         "dotenv": "16.5.0",
         "esbuild": "0.25.5",
         "gradient-string": "3.0.0",
-        "ronin": "6.7.7",
+        "ronin": "6.7.8",
       },
       "devDependencies": {
         "@hono/node-server": "1.14.4",
@@ -65,7 +65,7 @@
     },
     "packages/create-blade": {
       "name": "create-blade",
-      "version": "3.4.7",
+      "version": "3.4.10",
       "bin": {
         "create-blade": "./dist/index.js",
       },
@@ -838,7 +838,7 @@
 
     "rollup": ["rollup@4.44.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.44.1", "@rollup/rollup-android-arm64": "4.44.1", "@rollup/rollup-darwin-arm64": "4.44.1", "@rollup/rollup-darwin-x64": "4.44.1", "@rollup/rollup-freebsd-arm64": "4.44.1", "@rollup/rollup-freebsd-x64": "4.44.1", "@rollup/rollup-linux-arm-gnueabihf": "4.44.1", "@rollup/rollup-linux-arm-musleabihf": "4.44.1", "@rollup/rollup-linux-arm64-gnu": "4.44.1", "@rollup/rollup-linux-arm64-musl": "4.44.1", "@rollup/rollup-linux-loongarch64-gnu": "4.44.1", "@rollup/rollup-linux-powerpc64le-gnu": "4.44.1", "@rollup/rollup-linux-riscv64-gnu": "4.44.1", "@rollup/rollup-linux-riscv64-musl": "4.44.1", "@rollup/rollup-linux-s390x-gnu": "4.44.1", "@rollup/rollup-linux-x64-gnu": "4.44.1", "@rollup/rollup-linux-x64-musl": "4.44.1", "@rollup/rollup-win32-arm64-msvc": "4.44.1", "@rollup/rollup-win32-ia32-msvc": "4.44.1", "@rollup/rollup-win32-x64-msvc": "4.44.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-x8H8aPvD+xbl0Do8oez5f5o8eMS3trfCghc4HhLAnCkj7Vl0d1JWGs0UF/D886zLW2rOj2QymV/JcSSsw+XDNg=="],
 
-    "ronin": ["ronin@6.7.7", "", { "dependencies": { "@ronin/cli": "0.3.20", "@ronin/compiler": "0.18.10", "@ronin/engine": "0.1.23", "@ronin/syntax": "0.2.44" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-iKjHAWjWSY6SCLuXiPiT4N4qyZ6+K+0hDUYStxh67nBXGwbITdG8hdOx6z92O2VuKqAlG79kuvKDoHpBN5xUyQ=="],
+    "ronin": ["ronin@6.7.8", "", { "dependencies": { "@ronin/cli": "0.3.20", "@ronin/compiler": "0.18.10", "@ronin/engine": "0.1.23", "@ronin/syntax": "0.2.44" }, "bin": { "ronin": "dist/bin/index.js" } }, "sha512-wXBDht3++0NH952PKoixpXidD4J4D7qcOy0QpqDEqMmWsXK5+0VdnAWv8HnRh90QrtlTtUCe6g7hB5BWnqg2fA=="],
 
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -64,7 +64,7 @@
     "dotenv": "16.5.0",
     "esbuild": "0.25.5",
     "gradient-string": "3.0.0",
-    "ronin": "6.7.7"
+    "ronin": "6.7.8"
   },
   "devDependencies": {
     "@hono/node-server": "1.14.4",

--- a/packages/blade/private/shell/utils/providers.ts
+++ b/packages/blade/private/shell/utils/providers.ts
@@ -139,7 +139,7 @@ export const transformToCloudflareOutput = async (): Promise<void> => {
             name: currentDirectoryName,
             main: '.blade/edge-worker.js',
             compatibility_date: '2025-06-02',
-            compatibility_flags: ['nodejs_compat'],
+            compatibility_flags: [],
             assets: {
               binding: 'ASSETS',
               directory: '.blade/',


### PR DESCRIPTION
Blade does not need Node.js compatibility when using Cloudflare, because Blade outputs workers that only require web standards in order to function.