### PR TITLE
Handle `process.env` in dependencies

### DIFF
--- a/packages/blade/private/shell/utils/index.ts
+++ b/packages/blade/private/shell/utils/index.ts
@@ -191,13 +191,15 @@ export const composeEnvironmentVariables = (options: {
   // be logged to the terminal.
   defined['__BLADE_DEBUG_LEVEL'] = isLoggingQueries ? 'verbose' : 'error';
 
-  const mapped = Object.fromEntries(Object.entries(defined).map(([key, value]) => {
-    const stringValue = JSON.stringify(value);
-    return [`import.meta.env.${key}`, stringValue];
-  }));
+  const mapped = Object.fromEntries(
+    Object.entries(defined).map(([key, value]) => {
+      const stringValue = JSON.stringify(value);
+      return [`import.meta.env.${key}`, stringValue];
+    }),
+  );
 
   // This is the only `process.env` environment variable that we want to replace.
-  mapped['process.env.NODE_ENV'] = environment;
+  mapped['process.env.NODE_ENV'] = JSON.stringify(environment);
 
   return mapped;
 };


### PR DESCRIPTION
This change ensures that Blade correctly handles `process.env` in dependencies.