### PR TITLE
Improved reliability of server pushes

### DIFF
--- a/packages/blade/private/client/hooks.ts
+++ b/packages/blade/private/client/hooks.ts
@@ -53,7 +53,7 @@ export const usePageTransition = () => {
       // performing HMR, which cannot be slown down by the 10 second threadshold. Whereas
       // in production, caching a page for 10 seconds makes sense.
       if (cacheEntry && cacheEntry.time > maxAge && !IS_CLIENT_DEV) {
-        return () => window['BLADE_ROOT']!.render(cacheEntry.body);
+        return () => window['BLADE_SESSION']!.root.render(cacheEntry.body);
       }
     }
 
@@ -111,14 +111,14 @@ export const usePageTransition = () => {
     const pagePromise = pageTransitionQueue.add(
       async () => {
         const page = await fetchPage(path, options);
-        const root = window['BLADE_ROOT'];
+        const session = window['BLADE_SESSION'];
 
         // If the client bundles have changed, don't proceed, since `fetchPage` will
         // retrieve the latest bundles fresh in that case.
         //
-        // If no React root is available, new bundles are currently being mounted so we
-        // should clear the queue instead of proceeding.
-        if (!page || !root) {
+        // If no browser session is available, new bundles are currently being mounted so
+        // we should clear the queue instead of proceeding.
+        if (!page || !session) {
           // Immediately destroy the page queue, since we now know that the server has
           // changed, so we cannot continue processing any further requests from the old
           // client chunks. We have to do this inside the promise of the current function
@@ -169,7 +169,7 @@ export const usePageTransition = () => {
         if (!page) return;
 
         // Render the page.
-        window['BLADE_ROOT']!.render(page);
+        window['BLADE_SESSION']!.root.render(page);
       });
     };
   };

--- a/packages/blade/private/client/index.ts
+++ b/packages/blade/private/client/index.ts
@@ -8,17 +8,17 @@ import { mountNewBundle } from '@/private/client/utils/page';
 import { createFromReadableStream } from '@/private/client/utils/parser';
 
 if (!window['BLADE_SESSION']) {
-  const sessionId = crypto.randomUUID();
+  const id = crypto.randomUUID();
   const url = new URL('/_blade/session', window.location.origin);
 
-  // Inform the server about the page that is currently being viewed. Whenever the
-  // client retrieves a new page, the session will be updated on the server.
-  url.searchParams.set('id', sessionId);
+  // Inform the server about the page that is currently being viewed. Whenever the client
+  // retrieves a new page, the session will be updated on the server.
+  url.searchParams.set('id', id);
   url.searchParams.set('url', window.location.pathname + window.location.search);
   url.searchParams.set('bundleId', bundleId);
 
   // Open the event stream.
-  const eventSource = new EventSource(url, { withCredentials: true });
+  const source = new EventSource(url, { withCredentials: true });
 
   const handleMessage = async (message: MessageEvent) => {
     const serverBundleId = message.lastEventId.split('-').pop() as string;
@@ -36,7 +36,7 @@ if (!window['BLADE_SESSION']) {
           },
         });
 
-        window['BLADE_SESSION'] = { id: sessionId, source: eventSource, root };
+        window['BLADE_SESSION'] = { id, source, root };
       }
 
       return;
@@ -47,6 +47,6 @@ if (!window['BLADE_SESSION']) {
     }
   };
 
-  eventSource.addEventListener('update', handleMessage);
-  eventSource.addEventListener('update-bundle', handleMessage);
+  source.addEventListener('update', handleMessage);
+  source.addEventListener('update-bundle', handleMessage);
 }

--- a/packages/blade/private/client/index.ts
+++ b/packages/blade/private/client/index.ts
@@ -27,14 +27,16 @@ if (!window['BLADE_SESSION']) {
       const stream = new Blob([message.data]).stream();
       const body = await createFromReadableStream(stream);
 
-      if (window['BLADE_ROOT']) {
-        window['BLADE_ROOT'].render(body);
+      if (window['BLADE_SESSION']) {
+        window['BLADE_SESSION'].root.render(body);
       } else {
-        window['BLADE_ROOT'] = hydrateRoot(document, body, {
+        const root = hydrateRoot(document, body, {
           onRecoverableError(error, errorInfo) {
             console.error('Hydration error occurred:', error, errorInfo);
           },
         });
+
+        window['BLADE_SESSION'] = { id: sessionId, source: eventSource, root };
       }
 
       return;
@@ -47,6 +49,4 @@ if (!window['BLADE_SESSION']) {
 
   eventSource.addEventListener('update', handleMessage);
   eventSource.addEventListener('update-bundle', handleMessage);
-
-  window['BLADE_SESSION'] = { id: sessionId, source: eventSource };
 }

--- a/packages/blade/private/client/index.ts
+++ b/packages/blade/private/client/index.ts
@@ -8,15 +8,12 @@ import { mountNewBundle } from '@/private/client/utils/page';
 import { createFromReadableStream } from '@/private/client/utils/parser';
 
 if (!window['BLADE_SESSION']) {
-  window['BLADE_SESSION'] = crypto.randomUUID();
-}
-
-if (!window['BLADE_ROOT']) {
+  const sessionId = crypto.randomUUID();
   const url = new URL('/_blade/session', window.location.origin);
 
   // Inform the server about the page that is currently being viewed. Whenever the
   // client retrieves a new page, the session will be updated on the server.
-  url.searchParams.set('id', window['BLADE_SESSION'] as string);
+  url.searchParams.set('id', sessionId);
   url.searchParams.set('url', window.location.pathname + window.location.search);
   url.searchParams.set('bundleId', bundleId);
 
@@ -50,4 +47,6 @@ if (!window['BLADE_ROOT']) {
 
   eventSource.addEventListener('update', handleMessage);
   eventSource.addEventListener('update-bundle', handleMessage);
+
+  window['BLADE_SESSION'] = { id: sessionId, source: eventSource };
 }

--- a/packages/blade/private/client/types/global.d.ts
+++ b/packages/blade/private/client/types/global.d.ts
@@ -8,7 +8,10 @@ declare interface Window {
   BLADE_CHUNKS: Record<string, Record<string, unknown>>;
 
   // The ID of an ongoing browser session.
-  BLADE_SESSION: import('../../universal/types/util').BrowserSession['id'] | null;
+  BLADE_SESSION: {
+    id: import('../../universal/types/util').BrowserSession['id'];
+    source: EventSource;
+  } | null;
 }
 
 declare module 'client-list' {

--- a/packages/blade/private/client/types/global.d.ts
+++ b/packages/blade/private/client/types/global.d.ts
@@ -7,11 +7,11 @@ declare interface Window {
   BLADE_CHUNKS: Record<string, Record<string, unknown>>;
 
   /** An ongoing browser session (an open browser tab). */
-  BLADE_SESSION: {
+  BLADE_SESSION?: {
     id: import('../../universal/types/util').BrowserSession['id'];
     source: EventSource;
     root: import('react-dom/client').Root;
-  } | null;
+  };
 }
 
 declare module 'client-list' {

--- a/packages/blade/private/client/types/global.d.ts
+++ b/packages/blade/private/client/types/global.d.ts
@@ -1,16 +1,16 @@
-declare interface Window {
-  // It's extremely important that this remains a global instead of a variable exported
-  // from a file, as it must remain persistent across different script loads performed by
-  // the browser.
-  BLADE_ROOT: import('react-dom/client').Root | null;
+// It's extremely important that these remain globals instead of variables exported from
+// a file, as they must remain persistent across different script loads for different
+// client bundles performed by the browser.
 
-  // Contains a list of all the chunks that were loaded on the client so far.
+declare interface Window {
+  /** Contains a list of all the chunks that were loaded on the client so far. */
   BLADE_CHUNKS: Record<string, Record<string, unknown>>;
 
-  // The ID of an ongoing browser session.
+  /** An ongoing browser session (an open browser tab). */
   BLADE_SESSION: {
     id: import('../../universal/types/util').BrowserSession['id'];
     source: EventSource;
+    root: import('react-dom/client').Root;
   } | null;
 }
 

--- a/packages/blade/private/client/utils/page.ts
+++ b/packages/blade/private/client/utils/page.ts
@@ -93,8 +93,11 @@ export const mountNewBundle = async (bundleId: string, markup: Promise<string>) 
   // more updates might come in while we perform the next steps.
   session.source.close();
 
-  // Clear the session to prevent further updates from poll revalidation.
-  window['BLADE_SESSION'] = null;
+  // Clear the session to prevent further updates from poll revalidation. Deleting the
+  // property resets it back to exactly the state before the session was started (the
+  // property didn't exist at that time). It's more accurate than setting it to `null`,
+  // which would be third possible state.
+  delete window['BLADE_SESSION'];
 
   // Download the new markup, CSS, and JS at the same time, but don't execute any of them
   // just yet.

--- a/packages/blade/private/client/utils/page.ts
+++ b/packages/blade/private/client/utils/page.ts
@@ -84,18 +84,16 @@ export const fetchPage = async (
 };
 
 export const mountNewBundle = async (bundleId: string, markup: Promise<string>) => {
-  const root = window['BLADE_ROOT'];
   const session = window['BLADE_SESSION'];
 
-  // If there is no root or session, an update is still in progress.
-  if (!root || !session) return;
+  // If there is no active browser session, an update is still in progress.
+  if (!session) return;
 
   // As the first step, stop receiving further push updates from the server. Otherwise
   // more updates might come in while we perform the next steps.
   session.source.close();
 
-  // Clear the root and session to prevent further updates from poll revalidation.
-  window['BLADE_ROOT'] = null;
+  // Clear the session to prevent further updates from poll revalidation.
   window['BLADE_SESSION'] = null;
 
   // Download the new markup, CSS, and JS at the same time, but don't execute any of them
@@ -109,7 +107,7 @@ export const mountNewBundle = async (bundleId: string, markup: Promise<string>) 
   // Unmount React and replace the DOM with the static HTML markup, which then also loads
   // the updated CSS and JS bundles and mounts a new React root. This ensures that not
   // only the CSS and JS bundles can be upgraded, but also React itself.
-  root.unmount();
+  session.root.unmount();
 
   const parser = new DOMParser();
   const newDocument = parser.parseFromString(newMarkup, 'text/html');

--- a/packages/blade/private/client/utils/page.ts
+++ b/packages/blade/private/client/utils/page.ts
@@ -87,18 +87,19 @@ export const mountNewBundle = async (bundleId: string, markup: Promise<string>) 
   const root = window['BLADE_ROOT'];
   const session = window['BLADE_SESSION'];
 
-  // If there is no React root or session, an update is still in progress.
+  // If there is no root or session, an update is still in progress.
   if (!root || !session) return;
 
-  // Immediately clear the React root to prevent further updates from revalidation.
+  // As the first step, stop receiving further push updates from the server. Otherwise
+  // more updates might come in while we perform the next steps.
+  session.source.close();
+
+  // Clear the root and session to prevent further updates from poll revalidation.
   window['BLADE_ROOT'] = null;
   window['BLADE_SESSION'] = null;
 
-  // Stop receiving further updates from the server.
-  session.source.close();
-
-  // Download the new markup, CSS, and JS at the same time, but don't execute
-  // any of them just yet.
+  // Download the new markup, CSS, and JS at the same time, but don't execute any of them
+  // just yet.
   const [newMarkup] = await Promise.all([
     markup,
     loadResource(bundleId, 'style'),

--- a/packages/blade/private/client/utils/page.ts
+++ b/packages/blade/private/client/utils/page.ts
@@ -61,7 +61,7 @@ export const fetchPage = async (
 
   const headers = new Headers({
     Accept: 'application/json',
-    'X-Session-Id': window['BLADE_SESSION'] as string,
+    'X-Session-Id': window['BLADE_SESSION']?.id as string,
   });
 
   const response = await fetchRetry(path, { method: 'POST', body, headers });
@@ -85,13 +85,17 @@ export const fetchPage = async (
 
 export const mountNewBundle = async (bundleId: string, markup: Promise<string>) => {
   const root = window['BLADE_ROOT'];
+  const session = window['BLADE_SESSION'];
 
-  // If there is no React root, an update is still in progress.
-  if (!root) return;
+  // If there is no React root or session, an update is still in progress.
+  if (!root || !session) return;
 
   // Immediately clear the React root to prevent further updates from revalidation.
   window['BLADE_ROOT'] = null;
   window['BLADE_SESSION'] = null;
+
+  // Stop receiving further updates from the server.
+  session.source.close();
 
   // Download the new markup, CSS, and JS at the same time, but don't execute
   // any of them just yet.


### PR DESCRIPTION
This change ensures that the stream of server pushes is closed when a new client bundle mounts, since the stream relies on a particular version of React, which might get replaced with the new bundles.

Once the new bundles are mounted, they will automatically open a new stream themselves.