### PR TITLE
Disable SSE buffering in nginx

### DIFF
--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -234,6 +234,7 @@ app.get('/_blade/session', async (c) => {
   c.header('Content-Type', 'text/event-stream');
   c.header('Cache-Control', 'no-cache');
   c.header('Connection', 'keep-alive');
+  c.header('X-Accel-Buffering', 'no');
 
   const pageURL = new URL(sessionURL, currentURL);
   const correctBundle = sessionBundle === bundleId;


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/blade/pull/293 and ensures that nginx doesn't buffer SSEs provided by Blade.