### PR TITLE
Immediately establish server-push connection

### DIFF
--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -232,7 +232,7 @@ app.get('/_blade/session', async (c) => {
 
   c.header('Transfer-Encoding', 'chunked');
   c.header('Content-Type', 'text/event-stream');
-  c.header('Cache-Control', 'no-cache');
+  c.header('Cache-Control', 'no-cache, no-transform');
   c.header('Connection', 'keep-alive');
   c.header('X-Accel-Buffering', 'no');
 
@@ -255,7 +255,9 @@ app.get('/_blade/session', async (c) => {
     });
   }
 
-  await flushUpdate(stream, new Request(pageURL, c.req.raw), !correctBundle);
+  // Don't `await` this, so that the response stream gets returned immediately.
+  flushUpdate(stream, new Request(pageURL, c.req.raw), !correctBundle);
+
   return c.newResponse(stream.responseReadable);
 });
 

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -255,7 +255,8 @@ app.get('/_blade/session', async (c) => {
     });
   }
 
-  // Don't `await` this, so that the response stream gets returned immediately.
+  // Don't `await` this, so that the response headers get flushed immediately as a result
+  // of the response getting returned below.
   flushUpdate(stream, new Request(pageURL, c.req.raw), !correctBundle);
 
   return c.newResponse(stream.responseReadable);


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/blade/pull/298 and ensures that the SSE connection is established immediately, not after `flushUpdate` has finished running.