### PR TITLE
Revalidate UI from the server

### DIFF
--- a/packages/blade/private/client/components/history.tsx
+++ b/packages/blade/private/client/components/history.tsx
@@ -43,23 +43,6 @@ const HistoryContent = ({ children }: HistoryContentProps) => {
     return () => window.removeEventListener('focus', focused);
   }, [revalidate]);
 
-  // Update the records on the current page when the device goes back online.
-  useEffect(() => {
-    const wentOnline = () => revalidate('went online');
-
-    window.addEventListener('online', wentOnline);
-    return () => window.removeEventListener('online', wentOnline);
-  }, [revalidate]);
-
-  // Update the records on the current page while looking at the window. The update
-  // should be performed every 5 seconds, but to ensure that there are never two updates
-  // happening at once, we should only begin a new update once the last one has resulted
-  // in a successful render.
-  useEffect(() => {
-    const timeout = setTimeout(() => revalidate('interval'), 5000);
-    return () => clearTimeout(timeout);
-  }, [revalidate, universalContext.lastUpdate]);
-
   // Ensure that the address bar is updated whenever the page changes, but only if this
   // is desired by the trigger of the page change.
   useLayoutEffect(() => {

--- a/packages/blade/private/client/types/util.ts
+++ b/packages/blade/private/client/types/util.ts
@@ -5,9 +5,4 @@ type DeferredPromise<T> = {
 
 export type DeferredPromises<T = unknown> = Record<string, DeferredPromise<T>>;
 
-export type RevalidationReason =
-  | 'window focused'
-  | 'went online'
-  | 'interval'
-  | 'page changed'
-  | 'files updated';
+export type RevalidationReason = 'window focused';

--- a/packages/blade/private/server/context.ts
+++ b/packages/blade/private/server/context.ts
@@ -10,7 +10,7 @@ export type ServerContext<
     string,
     string | Array<string> | null
   >,
-> = Omit<UniversalContext<TParams>, 'collected' | 'lastUpdate'> & {
+> = Omit<UniversalContext<TParams>, 'collected'> & {
   cookies: Record<string, string | null>;
   collected: Collected;
   currentLeafIndex: number | null;

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -273,8 +273,12 @@ app.get('/_blade/session', async (c) => {
     url: pageURL,
     headers: c.req.raw.headers,
     stream,
-    interval: Promise.resolve(),
     bundleId: sessionBundle,
+    // We're purposefully using a `Promise` instead of `setInterval`, since the latter is
+    // prone to race conditions, because the interval continues running, even if the
+    // action hasn't yet been completed. Using our `Promise`, we ensure that the time
+    // only starts counting down once the action is completed.
+    interval: Promise.resolve(),
   };
 
   globalThis.SERVER_SESSIONS.set(sessionID, sessionDetails);

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -229,7 +229,7 @@ const flushSession = async (id: string, repeat?: boolean) => {
 //
 // In that case, we want to push an updated version of every page to the client.
 if (globalThis.SERVER_SESSIONS) {
-  globalThis.SERVER_SESSIONS.entries().map(([sessionId]) => flushSession(sessionId));
+  globalThis.SERVER_SESSIONS.forEach((_session, sessionId) => flushSession(sessionId));
 } else {
   globalThis.SERVER_SESSIONS = new Map();
 }

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -1,5 +1,5 @@
 import { DML_QUERY_TYPES_WRITE } from '@ronin/compiler';
-import { bundleId } from 'build-meta';
+import { bundleId as serverBundleId } from 'build-meta';
 import { getCookie } from 'hono/cookie';
 import { SSEStreamingApi } from 'hono/streaming';
 import { Hono } from 'hono/tiny';
@@ -174,42 +174,44 @@ app.post('/api', async (c) => {
 // If the application defines its own Hono instance, we need to mount it here.
 if (projectRouter) app.route('/', projectRouter);
 
-const flushUpdate = async (
-  stream: SSEStreamingApi,
-  url: URL,
-  headers: Headers,
-  initial: boolean,
-) => {
-  const page = await renderReactTree(url, headers, initial, {
+/**
+ * Renders a new React tree for a particular browser session and flushes it down to the
+ * client, which then updates the UI on the client.
+ *
+ * @param id - The ID of the session for which an update should be flushed.
+ * @param repeat - Whether to flush another update for the session later on.
+ *
+ * @returns If a `repeat` is not set, a promise that resolves once the session has been
+ * flushed once. Otherwise, if `repeat` is set, a promise that remains pending as long as
+ * the session continues to exist.
+ */
+const flushSession = async (id: string, repeat?: boolean) => {
+  const session = globalThis.SERVER_SESSIONS.get(id);
+
+  // If the session no longer exists, don't continue.
+  if (!session) return;
+
+  const { stream, url, headers, bundleId: clientBundleId } = session;
+  const correctBundle = clientBundleId === serverBundleId;
+
+  // If the session does exist, render an update for it.
+  const page = await renderReactTree(url, headers, !correctBundle, {
     waitUntil: getWaitUntil(),
   });
 
+  // Afterward, flush the update over the stream.
   await stream.writeSSE({
-    id: `${crypto.randomUUID()}-${bundleId}`,
-    event: initial ? 'update-bundle' : 'update',
+    id: `${crypto.randomUUID()}-${serverBundleId}`,
+    event: correctBundle ? 'update' : 'update-bundle',
     data: page.text(),
   });
-};
 
-const flushSessions = async () => {
-  const sessions = globalThis.SERVER_SESSIONS;
-
-  // If there aren't any sessions remaining, let the worker die.
-  if (sessions.size === 0) return;
-
-  // If there are open sessions remaining, update them.
-  await Promise.all(
-    sessions.entries().map(([, session]) => {
-      const { stream, url, headers } = session;
-      return flushUpdate(stream, url, headers, false);
-    }),
-  );
-
-  // Wait for 5 seconds before flushing the next update.
-  await sleep(5000);
-
-  // Attempt the next update.
-  flushSessions();
+  // If the update should be repeated later, wait for 5 seconds and then attempt
+  // flushing yet another update.
+  if (repeat) {
+    await sleep(5000);
+    return flushSession(id, repeat);
+  }
 };
 
 // If this variable is already defined when the file gets evaluated, that means the file
@@ -217,10 +219,7 @@ const flushSessions = async () => {
 //
 // In that case, we want to push an updated version of every page to the client.
 if (globalThis.SERVER_SESSIONS) {
-  for (const [, sessionDetails] of globalThis.SERVER_SESSIONS.entries()) {
-    const { url, headers, stream } = sessionDetails;
-    flushUpdate(stream, url, headers, true);
-  }
+  globalThis.SERVER_SESSIONS.entries().map(([sessionId]) => flushSession(sessionId));
 } else {
   globalThis.SERVER_SESSIONS = new Map();
 }
@@ -259,40 +258,27 @@ app.get('/_blade/session', async (c) => {
   c.header('X-Accel-Buffering', 'no');
 
   const pageURL = new URL(sessionURL, currentURL);
-  const correctBundle = sessionBundle === bundleId;
 
-  // If the bundles on the client and server are matching, track the session.
-  if (correctBundle) {
-    const sessionDetails = {
-      url: pageURL,
-      headers: c.req.raw.headers,
-      stream,
-    };
+  const sessionDetails = {
+    url: pageURL,
+    headers: c.req.raw.headers,
+    stream,
+    interval: Promise.resolve(),
+    bundleId: sessionBundle,
+  };
 
-    globalThis.SERVER_SESSIONS.set(sessionID, sessionDetails);
+  globalThis.SERVER_SESSIONS.set(sessionID, sessionDetails);
 
-    // Handle connection cleanup when the client disconnects.
-    c.req.raw.signal.addEventListener('abort', () => {
-      globalThis.SERVER_SESSIONS.delete(sessionID);
-    });
-  }
-
-  // Don't `await` this, so that the response headers get flushed immediately as a result
-  // of the response getting returned below.
-  flushUpdate(stream, pageURL, c.req.raw.headers, !correctBundle);
-
-  // Workers on Cloudflare get terminated as soon as the V8 event loop is empty, so we
-  // must ensure that the event loop remains populated as long as connections are open,
-  // otherwise the worker gets terminated, which results in the connection getting
-  // terminated as well.
+  // Once we've created the session, flush an update for it.
   //
-  // Using `waitUntil` with a promise that remains pending until the connection closes
-  // doesn't work because Cloudflare detects those kinds of forever-pending promises and
-  // forcefully terminates the worker in those cases, to avoid potential memory leaks.
-  //
-  // Since `setTimeout` does not count toward CPU time, Cloudflare thankfully doesn't
-  // charge for this idle time.
-  flushSessions();
+  // It's critical to not `await` this function call, since the response further below
+  // must be returned before the session is completely flushed (as quickly as possible).
+  sessionDetails.interval = flushSession(sessionID, true);
+
+  // Handle connection cleanup when the client disconnects.
+  c.req.raw.signal.addEventListener('abort', () => {
+    globalThis.SERVER_SESSIONS.delete(sessionID);
+  });
 
   return c.newResponse(stream.responseReadable);
 });

--- a/packages/blade/private/universal/context.ts
+++ b/packages/blade/private/universal/context.ts
@@ -15,7 +15,6 @@ export type UniversalContext<
   url: string;
   params: TParams extends Array<string> ? { [K in TParams[number]]: string } : TParams;
   userAgent: UserAgent;
-  lastUpdate: number;
   geoLocation: GeoLocation;
   addressBarInSync: boolean;
   languages: string[];
@@ -38,7 +37,6 @@ export const getSerializableContext = (
   url: serverContext.url,
   params: serverContext.params,
   userAgent: serverContext.userAgent,
-  lastUpdate: Date.now(),
   geoLocation: serverContext.geoLocation,
   addressBarInSync: serverContext.addressBarInSync,
   languages: serverContext.languages,

--- a/packages/blade/private/universal/types/util.ts
+++ b/packages/blade/private/universal/types/util.ts
@@ -25,6 +25,10 @@ export interface BrowserSession {
    * can be pushed.
    */
   stream: SSEStreamingApi;
+  /** A promise that continously revalidates the session as long as it is open. */
+  interval: Promise<void>;
+  /** The ID of the bundle that is currently being used on the client. */
+  bundleId: string;
 }
 
 interface QueryItemBase {


### PR DESCRIPTION
Now that Blade keeps a connection open to the server in order to flush UI updates, we can also handle our regular revalidation interval like that, by having the server push updates instead of having the clients poll them.

Since the SSE connection is automatically re-established after the device comes back online and the server already issues an immediate update for every newly established session, we also no longer need the client logic for revalidating when the device comes back online.

This will come in especially handy once we flush UI updates based on changes to data, since those stem from the server as well, which means they can all use a single pipeline.