### PR TITLE
Inline `Image` component

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,13 +11,12 @@
     },
     "packages/blade": {
       "name": "blade",
-      "version": "3.4.11",
+      "version": "3.5.6",
       "bin": {
         "blade": "./dist/private/shell/index.js",
       },
       "dependencies": {
         "@ronin/compiler": "0.18.9",
-        "@ronin/react": "0.1.4",
         "@ronin/syntax": "0.2.43",
         "@stefanprobst/rehype-extract-toc": "3.0.0",
         "@tailwindcss/node": "4.1.6",
@@ -64,7 +63,7 @@
     },
     "packages/create-blade": {
       "name": "create-blade",
-      "version": "3.4.11",
+      "version": "3.5.6",
       "bin": {
         "create-blade": "./dist/index.js",
       },
@@ -270,8 +269,6 @@
     "@ronin/compiler": ["@ronin/compiler@0.18.9", "", { "peerDependencies": { "@ronin/engine": ">=0.1.23" } }, "sha512-6h1YGdpcD/hUlrS4Mm9NvG+MlWcaPZ/+eaALSvxBXxxWb4dWcwtrtAU9/X3eZusSOa3MT6fbP3i1vDLdLWo/JA=="],
 
     "@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
-
-    "@ronin/react": ["@ronin/react@0.1.4", "", { "peerDependencies": { "@ronin/compiler": ">=0.18.7", "react": ">=18.3.1", "ronin": ">=6.6.13" } }, "sha512-VG+lgUBrJ2qKxzgpq9Wk3OV8r4u1L5Zv7UiLOkFm142W8XrZLnV0FyRW8QmFcMDtLPdWjqwfUYGYGZHR5EATQA=="],
 
     "@ronin/syntax": ["@ronin/syntax@0.2.43", "", { "peerDependencies": { "@ronin/compiler": ">=0.18.8" } }, "sha512-1ieYLB3SqmD2JfavuKcf/0gTwgZD4X859FDJ+8R5oO3BS1EUfGpfk1kQ0sYUgp+fM4pu0+4gjbHlNDi6Z998ag=="],
 
@@ -814,8 +811,6 @@
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "radash": ["radash@12.1.0", "", {}, "sha512-b0Zcf09AhqKS83btmUeYBS8tFK7XL2e3RvLmZcm0sTdF1/UUlHSsjXdCcWNxe7yfmAlPve5ym0DmKGtTzP6kVQ=="],
-
-    "react": ["react@19.1.0", "", {}, "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -54,7 +54,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@ronin/compiler": "0.18.9",
-    "@ronin/react": "0.1.4",
     "@ronin/syntax": "0.2.43",
     "@stefanprobst/rehype-extract-toc": "3.0.0",
     "@tailwindcss/node": "4.1.6",

--- a/packages/blade/public/client/components.tsx
+++ b/packages/blade/public/client/components.tsx
@@ -1,5 +1,12 @@
-import { Image as ImageComponent } from '@ronin/react';
-import { type AnchorHTMLAttributes, type ReactElement, cloneElement } from 'react';
+import type { StoredObject } from '@ronin/compiler';
+import {
+  type AnchorHTMLAttributes,
+  type ReactElement,
+  cloneElement,
+  forwardRef,
+  useCallback,
+  useRef,
+} from 'react';
 
 import { wrapClientComponent } from '@/private/client/utils/wrap-client';
 import { useUniversalContext } from '@/private/universal/hooks';
@@ -125,10 +132,241 @@ const Link = ({
   });
 };
 
-// We need to assign the component to a variable, otherwise `tsup` will remove the export
-// below and try to export it directly from the import, so `wrapClientComponent` would not
-// apply to it.
-const Image: typeof ImageComponent = ImageComponent;
+const supportedFitValues = ['fill', 'contain', 'cover'];
+
+interface BaseImageProps {
+  /**
+   * Defines text that can replace the image in the page.
+   */
+  alt?: string;
+  /**
+   * The quality level at which the image should be displayed. A lower quality ensures a
+   * faster loading speed, but might also effect the visual appearance, so it is
+   * essential to choose carefully.
+   *
+   * Must be an integer between `0` and `100`.
+   *
+   * @default 80
+   */
+  quality?: number;
+  /**
+   * The format of the image.
+   *
+   * @default "webp"
+   */
+  format?: 'webp' | 'jpeg' | 'png' | 'original';
+  /**
+   * The value of a RONIN blob field.
+   */
+  src: string | StoredObject;
+  /**
+   * Specifies how the image should be resized to fit its container.
+   *
+   * @default "cover"
+   */
+  fit?: React.CSSProperties['objectFit'];
+  /**
+   * The aspect ratio of the image. Can be "square", "video", or a custom string.
+   */
+  aspect?: 'square' | 'video' | string;
+  /**
+   * Indicates how the browser should load the image.
+   *
+   * Providing the value "lazy" defers loading the image until it reaches a calculated
+   * distance from the viewport, as defined by the browser. The intent is to avoid the
+   * network and storage impact needed to handle the image until it's reasonably certain
+   * that it will be needed. This generally improves the performance of the content in
+   * most typical use cases.
+   */
+  loading?: 'lazy';
+  /**
+   * The class names for the image container (not the image itself).
+   */
+  className?: string;
+  /**
+   * The inline style for the image container (not the image itself).
+   */
+  style?: React.CSSProperties;
+}
+
+type ImageProps = BaseImageProps &
+  (
+    | {
+        /**
+         * The intrinsic size of the image in pixels, if its width and height are the same.
+         * Must be an integer without a unit.
+         */
+        size: number;
+        /**
+         * The intrinsic width of the image in pixels. Must be an integer without a unit.
+         */
+        width?: never;
+        /**
+         * The intrinsic height of the image, in pixels. Must be an integer without a unit.
+         */
+        height?: never;
+      }
+    | {
+        /**
+         * The intrinsic size of the image in pixels, if its width and height are the same.
+         * Must be an integer without a unit.
+         */
+        size?: never;
+        /**
+         * The intrinsic width of the image in pixels. Must be an integer without a unit.
+         */
+        width?: number;
+        /**
+         * The intrinsic height of the image, in pixels. Must be an integer without a unit.
+         */
+        height: number;
+      }
+    | {
+        /**
+         * The intrinsic size of the image in pixels, if its width and height are the same.
+         * Must be an integer without a unit.
+         */
+        size?: never;
+        /**
+         * The intrinsic width of the image in pixels. Must be an integer without a unit.
+         */
+        width: number;
+        /**
+         * The intrinsic height of the image, in pixels. Must be an integer without a unit.
+         */
+        height?: number;
+      }
+  );
+
+const Image = forwardRef<HTMLDivElement, ImageProps>(
+  (
+    {
+      src: input,
+      alt,
+      size: defaultSize,
+      width: defaultWidth,
+      height: defaultHeight,
+      fit = 'cover',
+      format = 'webp',
+      quality = 80,
+      aspect,
+      loading,
+      style,
+      className,
+    },
+    ref,
+  ) => {
+    const imageElement = useRef<HTMLImageElement | null>(null);
+    const renderTime = useRef<number>(Date.now());
+
+    const isMediaObject = typeof input === 'object' && input !== null;
+    const width = defaultSize || defaultWidth;
+    const height = defaultSize || defaultHeight;
+
+    const onLoad = useCallback(() => {
+      const duration = Date.now() - renderTime.current;
+      const threshold = 150;
+
+      // Fade in and gradually reduce blur of the real image if loading takes longer than
+      // the specified threshold.
+      if (duration > threshold) {
+        imageElement.current?.animate(
+          [
+            { filter: 'blur(4px)', opacity: 0 },
+            { filter: 'blur(0px)', opacity: 1 },
+          ],
+          {
+            duration: 200,
+          },
+        );
+      }
+    }, []);
+
+    if (!(height || width))
+      throw new Error('Either `width`, `height`, or `size` must be defined for `Image`.');
+
+    // Validate given `quality` property.
+    if (quality && (quality < 0 || quality > 100))
+      throw new Error('The given `quality` was not in the range between 0 and 100.');
+
+    const optimizationParams = new URLSearchParams({
+      ...(width ? { w: width.toString() } : {}),
+      ...(height ? { h: height.toString() } : {}),
+      ...(format !== 'original' ? { fm: format } : {}),
+
+      fit: supportedFitValues.includes(fit) ? fit : 'cover',
+      q: quality.toString(),
+    });
+
+    const responsiveOptimizationParams = new URLSearchParams({
+      ...(width ? { h: (width * 2).toString() } : {}),
+      ...(height ? { h: (height * 2).toString() } : {}),
+      ...(format !== 'original' ? { fm: format } : {}),
+
+      fit: supportedFitValues.includes(fit) ? fit : 'cover',
+      q: quality.toString(),
+    });
+
+    const source = isMediaObject ? `${input.src}?${optimizationParams}` : input;
+
+    const responsiveSource = isMediaObject
+      ? `${input.src}?${optimizationParams} 1x, ` +
+        `${input.src}?${responsiveOptimizationParams} 2x`
+      : input;
+
+    const placeholder =
+      input && typeof input !== 'string' ? input.placeholder?.base64 : null;
+
+    return (
+      <div
+        ref={ref}
+        // biome-ignore lint/suspicious/noReactSpecificProps: This is a React library so React specific props are allowed.
+        className={className}
+        style={{
+          position: 'relative',
+          overflow: 'hidden',
+          flexShrink: 0,
+          width: width || '100%',
+          height: height || '100%',
+          aspectRatio: aspect === 'video' ? '16/9' : aspect === 'square' ? '1/1' : 'auto',
+          ...style,
+        }}>
+        {/* Blurred preview being displayed until the actual image is loaded. */}
+        {placeholder && (
+          // biome-ignore lint/nursery/noImgElement: An image component requires a `<img />` element.
+          <img
+            style={{
+              position: 'absolute',
+              width: '100%',
+              height: '100%',
+              objectFit: fit,
+            }}
+            src={placeholder}
+            alt={alt}
+          />
+        )}
+
+        {/* The optimized image, responsive to the specified size. */}
+        {/* biome-ignore lint/nursery/noImgElement: An image component requires a `<img />` element. */}
+        <img
+          alt={alt}
+          style={{
+            position: 'absolute',
+            width: '100%',
+            height: '100%',
+            objectFit: fit,
+          }}
+          decoding="async"
+          onLoad={onLoad}
+          loading={loading}
+          ref={imageElement}
+          src={source}
+          srcSet={responsiveSource}
+        />
+      </div>
+    );
+  },
+);
 
 wrapClientComponent(Link, 'Link');
 wrapClientComponent(Image, 'Image');


### PR DESCRIPTION
The `Image` component used to be located in a `@ronin/react` package, but it in favor of efficiency, it makes more sense to include it directly in Blade for now.

Every other framework has an `Image` component already, so I don't think anyone will need the `@ronin/react` package, but if that turns out to change in the future, we can consider splitting the component out again.

The reason why I'm adding the component to Blade is that `@ronin/react` has a peer dependency of `react`, which is not satisfied by the experimental React version that Blade apps currently use, so a newly created Blade app currently breaks when dependencies are installed with npm because npm will install two different `react` packages: A peer dependency for `@ronin/react` and the `react` that is defined in the app itself.

Of course I could change the peer dependency, but inlining it is more reliable long-term.