### PR TITLE
Prevent incorrect revalidation

### DIFF
--- a/packages/blade/private/client/hooks.ts
+++ b/packages/blade/private/client/hooks.ts
@@ -80,10 +80,10 @@ export const usePageTransition = () => {
     const pagePromise = pageTransitionQueue.add(async () => {
       const page = await fetchPage(path, {
         ...pageOptions,
-        // Don't pass a session ID yet, to ensure that the server-side session doesn't
-        // get updated yet. It should only get updated once the page was actually
-        // rendered, not when it was prefetched.
-        sessionId: options?.cache ? window['BLADE_SESSION']!.id : undefined,
+        // If the page should be cached, don't pass the session ID yet, to ensure that
+        // the server-side session doesn't get updated yet. It should only get updated
+        // once the page was actually rendered, not when it was prefetched.
+        sessionId: options?.cache ? undefined : window['BLADE_SESSION']!.id,
       });
 
       // Check the session again after `fetchPage` has finished running, since it might

--- a/packages/blade/private/client/utils/page.ts
+++ b/packages/blade/private/client/utils/page.ts
@@ -59,12 +59,11 @@ export const fetchPage = async (
     body = formData;
   }
 
-  const headers = new Headers({
-    Accept: 'application/json',
-    'X-Session-Id': window['BLADE_SESSION']?.id as string,
+  const response = await fetchRetry(path, {
+    method: 'POST',
+    body,
+    headers: { Accept: 'application/json' },
   });
-
-  const response = await fetchRetry(path, { method: 'POST', body, headers });
 
   // If the status code is not in the 200-299 range, we want to throw an error that will
   // be caught and rendered further upwards in the code.

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -542,9 +542,6 @@ const renderReactTree = async (
     forceNativeError: options.forceNativeError,
   });
 
-  // The ID of the browser session.
-  const sessionId = requestHeaders.get('X-Session-Id');
-
   const incomingCookies = structuredClone(
     parseCookies(requestHeaders.get('cookie') || ''),
   );
@@ -578,8 +575,8 @@ const renderReactTree = async (
     },
     currentLeafIndex: null,
     waitUntil: options.waitUntil,
-    flushSession: sessionId
-      ? (queries) => flushSession(sessionId, { queries })
+    flushSession: options.sessionId
+      ? (queries) => flushSession(options.sessionId as string, { queries })
       : undefined,
   };
 
@@ -840,7 +837,9 @@ const renderReactTree = async (
     );
   }
 
-  const session = sessionId ? global.SERVER_SESSIONS.get(sessionId) : null;
+  const session = options.sessionId
+    ? global.SERVER_SESSIONS.get(options.sessionId)
+    : null;
 
   // Update the server-side state to the new page.
   if (session) {

--- a/packages/blade/private/universal/types/util.ts
+++ b/packages/blade/private/universal/types/util.ts
@@ -94,6 +94,8 @@ export interface UserAgent {
 }
 
 export type PageFetchingOptions = {
+  /** A particular server-side session for which the page is being fetched. */
+  sessionId?: string;
   /**
    * This property is used by `useMutation` on the client and allows for processing
    * queries on the edge, after which the edge then makes the results of the queries

--- a/packages/blade/public/client/hooks.ts
+++ b/packages/blade/public/client/hooks.ts
@@ -224,7 +224,7 @@ export const useLinkEvents = (
     // We don't want to rely on `event.target` for retrieving the destination path, as
     // the event target might not be a link in the case that there are many nested
     // children present.
-    activeTransition.current = transitionPage(populatedPathname);
+    activeTransition.current = transitionPage(populatedPathname, { cache: true });
   };
 
   return {


### PR DESCRIPTION
This change ensures that [this bug](https://discord.com/channels/1099977902629589095/1392158060599967744/1392619471692370054) reported on Discord no longer occurs, meaning that hovering links will no longer cause a page transition — only clicking them will:

https://github.com/user-attachments/assets/acb9059a-da58-4cd9-a96e-2e5be0bc9c8d
