### PR TITLE
Default enable Cloudflare observability

### DIFF
--- a/packages/blade/private/shell/utils/providers.ts
+++ b/packages/blade/private/shell/utils/providers.ts
@@ -144,6 +144,12 @@ export const transformToCloudflareOutput = async (): Promise<void> => {
               binding: 'ASSETS',
               directory: '.blade/',
             },
+            observability: {
+              enabled: true,
+              logs: {
+                enabled: true,
+              },
+            },
           },
           null,
           4,


### PR DESCRIPTION
This change updates the default Wrangler config generated when deploying to Cloudflare to enable both observability & logging.