### PR TITLE
Add experimental package releases

### DIFF
--- a/.github/workflows/publish-experimental.yml
+++ b/.github/workflows/publish-experimental.yml
@@ -1,0 +1,28 @@
+name: Publish Experimental
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.18
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish packages
+        run: bunx pkg-pr-new publish './packages/*'


### PR DESCRIPTION
This change re-adds support for publishing experimental packages for us to use and test with, but this time using [pkg.pr.new](https://pkg.pr.new) for every PR.