### PR TITLE
Ensure `flushSession` is exposed to trigger options

### DIFF
--- a/packages/blade/private/server/worker/triggers.ts
+++ b/packages/blade/private/server/worker/triggers.ts
@@ -34,6 +34,7 @@ export const prepareTriggers = (
       languages: serverContext.languages,
     },
     location: new URL(serverContext.url),
+    flushSession: serverContext.flushSession,
   };
 
   const list = Object.entries(triggers || {}).map(


### PR DESCRIPTION
This change fixes a slight regression as part of #324 where I accidentally removed binding the server context `flushSession`  to the trigger options.