### PR TITLE
End revalidation when client disconnects

### DIFF
--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -272,7 +272,9 @@ app.post('*', async (c) => {
   globalThis.DEV_SESSIONS.set(id, { stream, url, headers });
 
   // Stop tracking the HMR session when the browser tab is closed.
-  c.req.raw.signal.addEventListener('abort', () => globalThis.DEV_SESSIONS.delete(id));
+  stream.onAbort(() => {
+    globalThis.DEV_SESSIONS.delete(id);
+  });
 
   return c.newResponse(stream.responseReadable);
 });

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -455,7 +455,9 @@ export const flushSession = async (
     repeat?: boolean;
   },
 ): Promise<void> => {
-  const queries = options?.queries;
+  // If the client is no longer connected, don't try to push an update. This therefore
+  // also breaks the interval of continuous revalidation.
+  if (stream.closed) return;
 
   const nestedFlushSession: ServerContext['flushSession'] = async (nestedQueries) => {
     const newOptions: Parameters<typeof flushSession>[4] = {
@@ -481,11 +483,11 @@ export const flushSession = async (
         waitUntil: getWaitUntil(),
         flushSession: options?.repeat ? nestedFlushSession : undefined,
       },
-      queries
+      options?.queries
         ? {
             jwts: {},
             metadata: {},
-            queries,
+            queries: options.queries,
           }
         : undefined,
     );

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -457,7 +457,7 @@ export const flushSession = async (
 ): Promise<void> => {
   // If the client is no longer connected, don't try to push an update. This therefore
   // also stops the interval of continuous revalidation.
-  if (stream.closed) return;
+  if (stream.aborted || stream.closed) return;
 
   const nestedFlushSession: ServerContext['flushSession'] = async (nestedQueries) => {
     const newOptions: Parameters<typeof flushSession>[4] = {

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -456,7 +456,7 @@ export const flushSession = async (
   },
 ): Promise<void> => {
   // If the client is no longer connected, don't try to push an update. This therefore
-  // also breaks the interval of continuous revalidation.
+  // also stops the interval of continuous revalidation.
   if (stream.closed) return;
 
   const nestedFlushSession: ServerContext['flushSession'] = async (nestedQueries) => {


### PR DESCRIPTION
This change ensures that the server doesn't try to push updates to clients that are no longer connected.