### PR TITLE
Revert: Switch `blade` to use workspace packages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,12 +6,12 @@
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/node": "24.0.4",
-        "turbo": "2.5.5",
+        "turbo": "2.5.4",
       },
     },
     "packages/blade": {
       "name": "blade",
-      "version": "3.7.4",
+      "version": "3.7.3",
       "bin": {
         "blade": "./dist/private/shell/index.js",
       },
@@ -20,10 +20,10 @@
         "@tailwindcss/node": "4.1.6",
         "@tailwindcss/oxide": "4.1.6",
         "@typescript-eslint/typescript-estree": "8.35.0",
-        "blade-client": "workspace:*",
         "dotenv": "16.5.0",
         "esbuild": "0.25.5",
         "gradient-string": "3.0.0",
+        "ronin": "6.8.0",
       },
       "devDependencies": {
         "@hono/node-server": "1.14.4",
@@ -62,7 +62,7 @@
     },
     "packages/blade-better-auth": {
       "name": "blade-better-auth",
-      "version": "3.7.4",
+      "version": "3.7.3",
       "dependencies": {
         "better-auth": "1.2.5",
       },
@@ -80,7 +80,7 @@
     },
     "packages/blade-cli": {
       "name": "blade-cli",
-      "version": "3.7.4",
+      "version": "3.7.3",
       "dependencies": {
         "@dprint/formatter": "0.4.1",
         "@dprint/typescript": "0.93.3",
@@ -112,7 +112,7 @@
     },
     "packages/blade-client": {
       "name": "blade-client",
-      "version": "3.7.4",
+      "version": "3.7.3",
       "bin": {
         "ronin": "./dist/bin/index.js",
       },
@@ -131,7 +131,7 @@
     },
     "packages/blade-codegen": {
       "name": "blade-codegen",
-      "version": "3.7.4",
+      "version": "3.7.3",
       "dependencies": {
         "typescript": "5.7.3",
       },
@@ -145,7 +145,7 @@
     },
     "packages/blade-compiler": {
       "name": "blade-compiler",
-      "version": "3.7.4",
+      "version": "3.7.3",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.14",
@@ -159,7 +159,7 @@
     },
     "packages/blade-hono": {
       "name": "blade-hono",
-      "version": "3.7.4",
+      "version": "3.7.3",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.18",
@@ -175,7 +175,7 @@
     },
     "packages/blade-syntax": {
       "name": "blade-syntax",
-      "version": "3.7.4",
+      "version": "3.7.3",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -187,7 +187,7 @@
     },
     "packages/create-blade": {
       "name": "create-blade",
-      "version": "3.7.4",
+      "version": "3.7.3",
       "bin": {
         "create-blade": "./dist/index.js",
       },
@@ -1192,19 +1192,19 @@
 
     "tsup": ["tsup@8.4.0", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.25.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-b+eZbPCjz10fRryaAA7C8xlIHnf8VnsaRqydheLIqwG/Mcpfk8Z5zp3HayX7GaTygkigHl5cBUs+IhcySiIexQ=="],
 
-    "turbo": ["turbo@2.5.5", "", { "optionalDependencies": { "turbo-darwin-64": "2.5.5", "turbo-darwin-arm64": "2.5.5", "turbo-linux-64": "2.5.5", "turbo-linux-arm64": "2.5.5", "turbo-windows-64": "2.5.5", "turbo-windows-arm64": "2.5.5" }, "bin": { "turbo": "bin/turbo" } }, "sha512-eZ7wI6KjtT1eBqCnh2JPXWNUAxtoxxfi6VdBdZFvil0ychCOTxbm7YLRBi1JSt7U3c+u3CLxpoPxLdvr/Npr3A=="],
+    "turbo": ["turbo@2.5.4", "", { "optionalDependencies": { "turbo-darwin-64": "2.5.4", "turbo-darwin-arm64": "2.5.4", "turbo-linux-64": "2.5.4", "turbo-linux-arm64": "2.5.4", "turbo-windows-64": "2.5.4", "turbo-windows-arm64": "2.5.4" }, "bin": { "turbo": "bin/turbo" } }, "sha512-kc8ZibdRcuWUG1pbYSBFWqmIjynlD8Lp7IB6U3vIzvOv9VG+6Sp8bzyeBWE3Oi8XV5KsQrznyRTBPvrf99E4mA=="],
 
-    "turbo-darwin-64": ["turbo-darwin-64@2.5.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-RYnTz49u4F5tDD2SUwwtlynABNBAfbyT2uU/brJcyh5k6lDLyNfYKdKmqd3K2ls4AaiALWrFKVSBsiVwhdFNzQ=="],
+    "turbo-darwin-64": ["turbo-darwin-64@2.5.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ah6YnH2dErojhFooxEzmvsoZQTMImaruZhFPfMKPBq8sb+hALRdvBNLqfc8NWlZq576FkfRZ/MSi4SHvVFT9PQ=="],
 
-    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.5.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Tk+ZeSNdBobZiMw9aFypQt0DlLsWSFWu1ymqsAdJLuPoAH05qCfYtRxE1pJuYHcJB5pqI+/HOxtJoQ40726Btw=="],
+    "turbo-darwin-arm64": ["turbo-darwin-arm64@2.5.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-2+Nx6LAyuXw2MdXb7pxqle3MYignLvS7OwtsP9SgtSBaMlnNlxl9BovzqdYAgkUW3AsYiQMJ/wBRb7d+xemM5A=="],
 
-    "turbo-linux-64": ["turbo-linux-64@2.5.5", "", { "os": "linux", "cpu": "x64" }, "sha512-2/XvMGykD7VgsvWesZZYIIVXMlgBcQy+ZAryjugoTcvJv8TZzSU/B1nShcA7IAjZ0q7OsZ45uP2cOb8EgKT30w=="],
+    "turbo-linux-64": ["turbo-linux-64@2.5.4", "", { "os": "linux", "cpu": "x64" }, "sha512-5May2kjWbc8w4XxswGAl74GZ5eM4Gr6IiroqdLhXeXyfvWEdm2mFYCSWOzz0/z5cAgqyGidF1jt1qzUR8hTmOA=="],
 
-    "turbo-linux-arm64": ["turbo-linux-arm64@2.5.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-DW+8CjCjybu0d7TFm9dovTTVg1VRnlkZ1rceO4zqsaLrit3DgHnN4to4uwyuf9s2V/BwS3IYcRy+HG9BL596Iw=="],
+    "turbo-linux-arm64": ["turbo-linux-arm64@2.5.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-/2yqFaS3TbfxV3P5yG2JUI79P7OUQKOUvAnx4MV9Bdz6jqHsHwc9WZPpO4QseQm+NvmgY6ICORnoVPODxGUiJg=="],
 
-    "turbo-windows-64": ["turbo-windows-64@2.5.5", "", { "os": "win32", "cpu": "x64" }, "sha512-q5p1BOy8ChtSZfULuF1BhFMYIx6bevXu4fJ+TE/hyNfyHJIfjl90Z6jWdqAlyaFLmn99X/uw+7d6T/Y/dr5JwQ=="],
+    "turbo-windows-64": ["turbo-windows-64@2.5.4", "", { "os": "win32", "cpu": "x64" }, "sha512-EQUO4SmaCDhO6zYohxIjJpOKRN3wlfU7jMAj3CgcyTPvQR/UFLEKAYHqJOnJtymbQmiiM/ihX6c6W6Uq0yC7mA=="],
 
-    "turbo-windows-arm64": ["turbo-windows-arm64@2.5.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-AXbF1KmpHUq3PKQwddMGoKMYhHsy5t1YBQO8HZ04HLMR0rWv9adYlQ8kaeQJTko1Ay1anOBFTqaxfVOOsu7+1Q=="],
+    "turbo-windows-arm64": ["turbo-windows-arm64@2.5.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-oQ8RrK1VS8lrxkLriotFq+PiF7iiGgkZtfLKF4DDKsmdbPo0O9R2mQxm7jHLuXraRCuIQDWMIw6dpcr7Iykf4A=="],
 
     "type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/node": "24.0.4",
-    "turbo": "2.5.5"
+    "turbo": "2.5.4"
   }
 }

--- a/packages/blade-better-auth/src/index.ts
+++ b/packages/blade-better-auth/src/index.ts
@@ -22,8 +22,8 @@ import {
 } from '@/transform';
 
 import type { Adapter, AdapterInstance } from 'better-auth/types';
-import type { ResultRecordBase } from 'blade-compiler';
 import type { createSyntaxFactory } from 'ronin';
+import type { ResultRecordBase } from 'blade-compiler';
 
 type SyntaxFactory = ReturnType<typeof createSyntaxFactory>;
 
@@ -36,7 +36,7 @@ type SyntaxFactory = ReturnType<typeof createSyntaxFactory>;
  *
  * @example
  * ```ts
- * import { ronin } from 'blade-better-auth';
+ * import { ronin } from '@ronin/better-auth';
  * import { betterAuth } from 'better-auth';
  *
  * const auth = betterAuth({
@@ -46,7 +46,7 @@ type SyntaxFactory = ReturnType<typeof createSyntaxFactory>;
  *
  * @example
  * ```ts
- * import { ronin } from 'blade-better-auth';
+ * import { ronin } from '@ronin/better-auth';
  * import { createSyntaxFactory } from 'ronin';
  * import { betterAuth } from 'better-auth';
  *

--- a/packages/blade-better-auth/tests/index.test.ts
+++ b/packages/blade-better-auth/tests/index.test.ts
@@ -10,6 +10,7 @@ describe('adapter', () => {
 
   describe('authentication', () => {
     test('with no `RONIN_TOKEN` set', async () => {
+      // biome-ignore lint/nursery/noProcessEnv: We're intentionally overriding this environment variable.
       process.env.RONIN_TOKEN = undefined;
 
       const { auth } = await init({
@@ -28,6 +29,7 @@ describe('adapter', () => {
     });
 
     test('with an invalid `RONIN_TOKEN`', async () => {
+      // biome-ignore lint/nursery/noProcessEnv: We're intentionally overriding this environment variable.
       process.env.RONIN_TOKEN = 'abc123';
 
       const { auth } = await init({
@@ -47,6 +49,7 @@ describe('adapter', () => {
       const MOCK_JWT =
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiIiLCJleHAiOjAsImlhdCI6MCwiaXNzIjoiIiwic3ViIjoiIiwidGtuIjoiIn0.QwdhNGPGS1Rt3se0yBYi6XJLOPEg4cSNdBUjd8EOXaQ';
 
+      // biome-ignore lint/nursery/noProcessEnv: We're intentionally overriding this environment variable.
       process.env.RONIN_TOKEN = MOCK_JWT;
 
       const { auth } = await init({

--- a/packages/blade-cli/tests/fixtures/protocol.ts
+++ b/packages/blade-cli/tests/fixtures/protocol.ts
@@ -1,3 +1,4 @@
 import { get } from 'ronin';
 
+// biome-ignore lint/nursery/useExplicitType: In a real scenario, there is no type.
 export default () => [get.account.with({ handle: 'elaine' })];

--- a/packages/blade-cli/tests/index.test.ts
+++ b/packages/blade-cli/tests/index.test.ts
@@ -506,6 +506,7 @@ describe('CLI', () => {
 
   describe('migration', () => {
     // Common migration test setup
+    // biome-ignore lint/nursery/useExplicitType: This is a mock.
     const setupMigrationTest = (options?: {
       modelDiff?: Array<ModelWithFieldsArray>;
       modelDefinitions?: Array<Model>;

--- a/packages/blade-cli/tests/utils/model.test.ts
+++ b/packages/blade-cli/tests/utils/model.test.ts
@@ -129,7 +129,7 @@ describe('models', async () => {
         method: 'POST',
       });
 
-      spyOn(logInModule, 'default').mockImplementation(() => {
+      spyOn(logInModule, 'default').mockImplementation(async () => {
         throw new Error(
           'Failed to fetch remote models: This session is no longer valid.',
         );

--- a/packages/blade-cli/tests/utils/protocol.test.ts
+++ b/packages/blade-cli/tests/utils/protocol.test.ts
@@ -8,12 +8,12 @@ describe('protocol', () => {
     jest.clearAllMocks();
   });
 
-  test('should initialize with empty queries when none are provided', () => {
+  test('should initialize with empty queries when none are provided', async () => {
     const protocol = new Protocol();
     expect(protocol.queries).toEqual([]);
   });
 
-  test('should initialize with provided queries', () => {
+  test('should initialize with provided queries', async () => {
     const queries = ["create.model({slug: 'model', pluralSlug: 'models'})"];
     const protocol = new Protocol(queries);
     expect(protocol.queries).toEqual([]);

--- a/packages/blade-client/tests/integration/edge.test.ts
+++ b/packages/blade-client/tests/integration/edge.test.ts
@@ -79,7 +79,6 @@ describe('edge runtime', () => {
     await runQueriesWithTriggers(
       queries.map((query) => ({ query })),
       {
-        // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
         fetch: async () => {
           return Response.json({
             results: [
@@ -139,7 +138,6 @@ describe('edge runtime', () => {
     await runQueriesWithTriggers(
       queries.map((query) => ({ query })),
       {
-        // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
         fetch: async () => {
           return Response.json({
             results: [
@@ -191,7 +189,6 @@ describe('edge runtime', () => {
     await runQueriesWithTriggers(
       queries.map((query) => ({ query })),
       {
-        // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
         fetch: async () => {
           return Response.json({
             results: [

--- a/packages/blade-client/tests/integration/factory.test.ts
+++ b/packages/blade-client/tests/integration/factory.test.ts
@@ -442,7 +442,6 @@ describe('factory', () => {
 
   test('correctly format `amount`', async () => {
     const factory = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async (request) => {
         mockRequestResolvedValue = request as Request;
 
@@ -463,7 +462,6 @@ describe('factory', () => {
 
   test('correctly format not found result', async () => {
     const factory = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async (request) => {
         mockRequestResolvedValue = request as Request;
 
@@ -487,7 +485,6 @@ describe('factory', () => {
     let mockResolvedStorageRequest: Request | undefined;
 
     const factory = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async (request) => {
         if ((request as Request).url === 'https://storage.ronin.co/') {
           mockResolvedStorageRequest = request as Request;
@@ -552,7 +549,6 @@ describe('factory', () => {
     let mockResolvedStorageRequest: Request | undefined;
 
     const factory = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async (request) => {
         if ((request as Request).url === 'https://storage.ronin.co/') {
           mockResolvedStorageRequest = request as Request;
@@ -603,7 +599,6 @@ describe('factory', () => {
     let mockResolvedStorageRequest: Request | undefined;
 
     const factory = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async (request) => {
         if ((request as Request).url === 'https://storage.ronin.co/') {
           mockResolvedStorageRequest = request as Request;
@@ -651,7 +646,6 @@ describe('factory', () => {
 
   test('handle storage service error', async () => {
     const factory = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async (request) => {
         if ((request as Request).url === 'https://storage.ronin.co/') {
           return new Response('Details here', {
@@ -674,7 +668,7 @@ describe('factory', () => {
   });
 
   test('format date fields', async () => {
-    const mockFetchNew = mock((request) => {
+    const mockFetchNew = mock(async (request) => {
       mockRequestResolvedValue = request;
 
       return Response.json({
@@ -747,7 +741,7 @@ describe('factory', () => {
   });
 
   test('format expanded results', async () => {
-    const mockFetchNew = mock((request) => {
+    const mockFetchNew = mock(async (request) => {
       mockRequestResolvedValue = request;
 
       return Response.json({

--- a/packages/blade-client/tests/integration/triggers.test.ts
+++ b/packages/blade-client/tests/integration/triggers.test.ts
@@ -205,7 +205,6 @@ describe('triggers', () => {
     let finalAfterResult: unknown;
 
     const { create } = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async () => {
         return Response.json({
           results: [
@@ -350,7 +349,6 @@ describe('triggers', () => {
     let finalAfterResult: unknown;
 
     const { drop } = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async () => {
         return Response.json({
           results: [
@@ -403,7 +401,6 @@ describe('triggers', () => {
     let finalAfterResult: unknown;
 
     const { remove } = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async () => {
         return Response.json({
           results: [
@@ -474,7 +471,6 @@ describe('triggers', () => {
     ];
 
     const { set } = createSyntaxFactory({
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async () => {
         return Response.json({
           results: [{ records: previousAccounts }, { records: nextAccounts }],

--- a/packages/blade-client/tests/unit/queries.test.ts
+++ b/packages/blade-client/tests/unit/queries.test.ts
@@ -6,16 +6,13 @@ import type { Query } from 'blade-compiler';
 
 let mockRequestResolvedValue: Request | undefined;
 
-const mockFetch = mock(
-  // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
-  async (request) => {
-    mockRequestResolvedValue = request;
+const mockFetch = mock(async (request) => {
+  mockRequestResolvedValue = request;
 
-    return Response.json({
-      results: [],
-    });
-  },
-);
+  return Response.json({
+    results: [],
+  });
+});
 
 global.fetch = mockFetch;
 
@@ -100,7 +97,6 @@ describe('queries handler', () => {
   test('handle BAD_REQUEST response', async () => {
     const requestPromise = queriesHandler([], {
       token: 'takashitoken',
-      // biome-ignore lint/suspicious/useAwait: `fetch` requires a promise return.
       fetch: async (request) => {
         mockRequestResolvedValue = request as Request;
 

--- a/packages/blade-codegen/src/constants/identifiers.ts
+++ b/packages/blade-codegen/src/constants/identifiers.ts
@@ -59,7 +59,7 @@ export const identifiers = {
 } satisfies Record<string, Record<string, Identifier | Record<string, Identifier>>>;
 
 /**
- * A list of all generic names used in the `blade-codegen` package.
+ * A list of all generic names used in the `@ronin/codegen` package.
  *
  * Similar to `identifiers` but designed specifically for use as generic names.
  */

--- a/packages/blade-compiler/src/index.ts
+++ b/packages/blade-compiler/src/index.ts
@@ -158,9 +158,14 @@ class Transaction {
 
     for (const { query, index, expansion } of expandedQueries) {
       const { dependencies, main, selectedFields, model, updatedQuery } =
-        compileQueryInput(query, modelsWithPresets, options?.inlineParams ? null : [], {
-          inlineDefaults: options?.inlineDefaults || false,
-        });
+        compileQueryInput(
+          query,
+          modelsWithPresets,
+          options?.inlineParams ? null : [],
+
+          // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
+          { inlineDefaults: options?.inlineDefaults || false },
+        );
 
       // Every query can only produce one main statement (which can return output), but
       // multiple dependency statements (which must be executed either before or after

--- a/packages/blade-compiler/src/instructions/to.ts
+++ b/packages/blade-compiler/src/instructions/to.ts
@@ -120,6 +120,7 @@ export const handleTo = (
     }
 
     statement += compileQueryInput(symbol.value, models, statementParams, {
+      // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
       inlineDefaults: options?.inlineDefaults || false,
     }).main.statement;
     return statement;
@@ -167,6 +168,7 @@ export const handleTo = (
           },
           models,
           [],
+          // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
           { returning: false, inlineDefaults: options?.inlineDefaults || false },
         ).main;
 

--- a/packages/blade-compiler/src/utils/index.ts
+++ b/packages/blade-compiler/src/utils/index.ts
@@ -79,6 +79,7 @@ export const compileQueryInput = (
     statementParams,
     defaultQuery,
     {
+      // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
       inlineDefaults: options?.inlineDefaults || false,
     },
   );
@@ -173,6 +174,7 @@ export const compileQueryInput = (
       orderedBy: instructions?.orderedBy,
       limitedTo: instructions?.limitedTo,
     },
+    // biome-ignore lint/complexity/useSimplifiedLogicExpression: This is needed.
     { inlineDefaults: options?.inlineDefaults || false },
   );
 

--- a/packages/blade-hono/src/index.ts
+++ b/packages/blade-hono/src/index.ts
@@ -34,7 +34,7 @@ interface Options extends QueryHandlerOptions {}
  * @example
  * ```ts
  * import { Hono } from 'hono';
- * import { ronin, type Bindings, type Variables } from 'blade-hono';
+ * import { ronin, type Bindings, type Variables } from '@ronin/hono';
  *
  * const app = new Hono()
  * 	.use('*', ronin())

--- a/packages/blade-hono/tests/integration.test.ts
+++ b/packages/blade-hono/tests/integration.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import { createFactory } from 'hono/factory';
 import { testClient } from 'hono/testing';
 

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -57,10 +57,10 @@
     "@tailwindcss/node": "4.1.6",
     "@tailwindcss/oxide": "4.1.6",
     "@typescript-eslint/typescript-estree": "8.35.0",
-    "blade-client": "workspace:*",
     "dotenv": "16.5.0",
     "esbuild": "0.25.5",
-    "gradient-string": "3.0.0"
+    "gradient-string": "3.0.0",
+    "ronin": "6.8.0"
   },
   "devDependencies": {
     "@hono/node-server": "1.14.4",

--- a/packages/blade/private/server/context.ts
+++ b/packages/blade/private/server/context.ts
@@ -1,5 +1,5 @@
-import type { Query } from 'blade-compiler';
 import { createContext } from 'react';
+import type { Query } from 'ronin/types';
 
 import type { WaitUntil } from '@/private/server/types';
 import type { Collected } from '@/private/server/worker/tree';

--- a/packages/blade/private/server/types/index.ts
+++ b/packages/blade/private/server/types/index.ts
@@ -1,3 +1,4 @@
+import type { ComponentType, FunctionComponent } from 'react';
 import type {
   AddTrigger as OriginalAddTrigger,
   AfterAddTrigger as OriginalAfterAddTrigger,
@@ -24,8 +25,7 @@ import type {
   ResolvingRemoveTrigger as OriginalResolvingRemoveTrigger,
   ResolvingSetTrigger as OriginalResolvingSetTrigger,
   SetTrigger as OriginalSetTrigger,
-} from 'blade-client/types';
-import type { ComponentType, FunctionComponent } from 'react';
+} from 'ronin/types';
 
 import type { ServerContext } from '@/private/server/context';
 import type { CustomNavigator } from '@/private/universal/types/util';

--- a/packages/blade/private/server/utils/data.ts
+++ b/packages/blade/private/server/utils/data.ts
@@ -1,8 +1,8 @@
-import { waitUntil as vercelWaitUntil } from '@vercel/functions';
-import type { FormattedResults, QueryHandlerOptions } from 'blade-client/types';
-import { runQueries as runQueriesOnRonin } from 'blade-client/utils';
 import type { Query, ResultRecord } from 'blade-compiler';
+import { waitUntil as vercelWaitUntil } from '@vercel/functions';
 import type { Context, ExecutionContext } from 'hono';
+import type { FormattedResults, QueryHandlerOptions } from 'ronin/types';
+import { runQueries as runQueriesOnRonin } from 'ronin/utils';
 
 import type { TriggersList, WaitUntil } from '@/private/server/types';
 import { VERBOSE_LOGGING } from '@/private/server/utils/constants';

--- a/packages/blade/private/server/utils/files.ts
+++ b/packages/blade/private/server/utils/files.ts
@@ -1,4 +1,4 @@
-import type { Query, QueryType, StoredObject } from 'blade-client/types';
+import type { Query, QueryType, StoredObject } from 'ronin/types';
 
 /**
  * Replaces `StoredObject` references in a list of queries with real `File` instances

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -1,10 +1,10 @@
-import type { Query, QueryType } from 'blade-client/types';
-import { ClientError } from 'blade-client/utils';
 import { DML_QUERY_TYPES_WRITE } from 'blade-compiler';
 import { bundleId as serverBundleId } from 'build-meta';
 import { getCookie } from 'hono/cookie';
 import { SSEStreamingApi } from 'hono/streaming';
 import { Hono } from 'hono/tiny';
+import type { Query, QueryType } from 'ronin/types';
+import { ClientError } from 'ronin/utils';
 import { router as projectRouter, triggers as triggerList } from 'server-list';
 
 import type { ServerContext } from '@/private/server/context';

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -1,6 +1,4 @@
 import type { Toc } from '@stefanprobst/rehype-extract-toc';
-import type { FormattedResults, Query } from 'blade-client/types';
-import { ClientError } from 'blade-client/utils';
 import { bundleId as serverBundleId } from 'build-meta';
 import {
   type CookieSerializeOptions,
@@ -14,6 +12,8 @@ import { sleep } from 'radash';
 import React, { type ReactNode } from 'react';
 // @ts-expect-error `@types/react-dom` is missing types for this file.
 import { renderToReadableStream as renderToReadableStreamInitial } from 'react-dom/server.browser';
+import type { FormattedResults, Query } from 'ronin/types';
+import { ClientError } from 'ronin/utils';
 import { serializeError } from 'serialize-error';
 import { pages as pageList, triggers as triggerList } from 'server-list';
 

--- a/packages/blade/private/server/worker/triggers.ts
+++ b/packages/blade/private/server/worker/triggers.ts
@@ -34,6 +34,7 @@ export const prepareTriggers = (
       languages: serverContext.languages,
     },
     location: new URL(serverContext.url),
+    flushSession: serverContext.flushSession,
   };
 
   const list = Object.entries(triggers || {}).map(

--- a/packages/blade/private/server/worker/triggers.ts
+++ b/packages/blade/private/server/worker/triggers.ts
@@ -1,4 +1,4 @@
-import type { BeforeGetTrigger } from 'blade-client/types';
+import type { BeforeGetTrigger } from 'ronin/types';
 
 import type { ServerContext } from '@/private/server/context';
 import type {
@@ -34,6 +34,7 @@ export const prepareTriggers = (
       languages: serverContext.languages,
     },
     location: new URL(serverContext.url),
+    flushSession: serverContext.flushSession,
   };
 
   const list = Object.entries(triggers || {}).map(

--- a/packages/blade/private/server/worker/triggers.ts
+++ b/packages/blade/private/server/worker/triggers.ts
@@ -34,7 +34,6 @@ export const prepareTriggers = (
       languages: serverContext.languages,
     },
     location: new URL(serverContext.url),
-    flushSession: serverContext.flushSession,
   };
 
   const list = Object.entries(triggers || {}).map(

--- a/packages/blade/private/universal/types/util.ts
+++ b/packages/blade/private/universal/types/util.ts
@@ -1,5 +1,5 @@
-import type { FormattedResults } from 'blade-client/types';
 import type { SSEStreamingApi } from 'hono/streaming';
+import type { FormattedResults } from 'ronin/types';
 
 import type { UniversalContext } from '@/private/universal/context';
 

--- a/packages/blade/public/client/components.tsx
+++ b/packages/blade/public/client/components.tsx
@@ -320,6 +320,7 @@ const Image = forwardRef<HTMLDivElement, ImageProps>(
     return (
       <div
         ref={ref}
+        // biome-ignore lint/suspicious/noReactSpecificProps: This is a React library so React specific props are allowed.
         className={className}
         style={{
           position: 'relative',

--- a/packages/blade/public/client/hooks.ts
+++ b/packages/blade/public/client/hooks.ts
@@ -1,4 +1,3 @@
-import { isStorableObject, processStorableObjects } from 'blade-client/utils';
 import type { Query } from 'blade-compiler';
 import {
   type AddQuery,
@@ -23,6 +22,7 @@ import {
   useMemo,
   useRef,
 } from 'react';
+import { isStorableObject, processStorableObjects } from 'ronin/utils';
 import { deserializeError } from 'serialize-error';
 
 import { RootClientContext } from '@/private/client/context';

--- a/packages/blade/public/universal/schema.ts
+++ b/packages/blade/public/universal/schema.ts
@@ -1,1 +1,1 @@
-export * from 'blade-client/schema';
+export * from 'ronin/schema';

--- a/packages/blade/public/universal/types.ts
+++ b/packages/blade/public/universal/types.ts
@@ -29,6 +29,6 @@ export type {
   TableOfContents,
 } from '@/private/server/types';
 
-export type * from 'blade-client';
-export type * from 'blade-client/types';
+export type * from 'ronin';
+export type * from 'ronin/types';
 export type { ResultRecord } from 'blade-compiler';


### PR DESCRIPTION
This change reverts the changes previously applied in both #324 and #332, since it seems to have caused a number of upstream issues with exports.