### PR TITLE
Ensure correct schema imports

### DIFF
--- a/docs/pages/models/index.mdx
+++ b/docs/pages/models/index.mdx
@@ -41,12 +41,12 @@ mkdir schema
 touch schema/index.ts
 ```
 
-A model is defined using the `model()` function provided by the RONIN client under the `ronin/schema` path. The `ronin/schema` path also provides all field type primitives, such as `string()`, `number()`, or `blob()`.
+A model is defined using the `model()` function provided by the RONIN client under the `blade/schema` path. The `ronin/schema` path also provides all field type primitives, such as `string()`, `number()`, or `blob()`.
 
 Here is an example of a basic schema definition:
 
 ```ts title="schema/index.ts"
-import { model, string, date } from 'ronin/schema';
+import { model, string, date } from 'blade/schema';
 
 export const Account = model({
   slug: 'account',
@@ -129,7 +129,7 @@ The following types can be used to define fields in a model:
 You can define the relationship of a field to another model like so:
 
 ```ts title="schema/index.ts"
-import { model, string, date, link } from 'ronin/schema';
+import { model, string, date, link } from 'blade/schema';
 
 export const Account = model({
   slug: 'account',

--- a/docs/pages/models/index.mdx
+++ b/docs/pages/models/index.mdx
@@ -41,7 +41,7 @@ mkdir schema
 touch schema/index.ts
 ```
 
-A model is defined using the `model()` function provided by the RONIN client under the `blade/schema` path. The `ronin/schema` path also provides all field type primitives, such as `string()`, `number()`, or `blob()`.
+A model is defined using the `model()` function provided by the RONIN client under the `blade/schema` path. The `blade/schema` path also provides all field type primitives, such as `string()`, `number()`, or `blob()`.
 
 Here is an example of a basic schema definition:
 

--- a/docs/pages/queries/functions.mdx
+++ b/docs/pages/queries/functions.mdx
@@ -4,14 +4,14 @@ title: 'Functions'
 
 # Functions
 
-RONIN provides a set of SQL functions that can be used in queries to manipulate data. These functions can be imported from `ronin/schema`.
+RONIN provides a set of SQL functions that can be used in queries to manipulate data. These functions can be imported from `blade/schema`.
 
 ### random
 
 Generates a pseudo-random integer between `-9223372036854775808` and `+9223372036854775807`.
 
 ```ts
-import { random } from 'ronin/schema';
+import { random } from 'blade/schema';
 
 // Usage
 await set.user(fields => ({
@@ -27,7 +27,7 @@ await set.user(fields => ({
 Calculates the absolute value of a number.
 
 ```ts
-import { abs } from 'ronin/schema';
+import { abs } from 'blade/schema';
 
 // Usage
 await set.transaction(fields => ({
@@ -45,7 +45,7 @@ await set.transaction(fields => ({
 Formats a timestamp according to the specified format string.
 
 ```ts
-import { strftime } from 'ronin/schema';
+import { strftime } from 'blade/schema';
 
 // Usage
 await set.log(fields => ({
@@ -63,7 +63,7 @@ await set.log(fields => ({
 Extracts a value from a JSON document at the specified path.
 
 ```ts
-import { json_extract } from 'ronin/schema';
+import { json_extract } from 'blade/schema';
 
 // Usage
 await set.user(fields => ({
@@ -79,7 +79,7 @@ await set.user(fields => ({
 Applies a JSON patch operation to a JSON document.
 
 ```ts
-import { json_patch } from 'ronin/schema';
+import { json_patch } from 'blade/schema';
 
 // Usage
 await set.user(fields => ({
@@ -95,7 +95,7 @@ await set.user(fields => ({
 Sets a value in a JSON document at the specified path. Creates the path if it doesn't exist and overwrites if it does.
 
 ```ts
-import { json_set } from 'ronin/schema';
+import { json_set } from 'blade/schema';
 
 // Usage
 await set.user(fields => ({
@@ -111,7 +111,7 @@ await set.user(fields => ({
 Replaces a value in a JSON document at the specified path. Only modifies existing paths, will not create new ones.
 
 ```ts
-import { json_replace } from 'ronin/schema';
+import { json_replace } from 'blade/schema';
 
 // Usage
 await set.user(fields => ({
@@ -127,7 +127,7 @@ await set.user(fields => ({
 Inserts a value into a JSON document at the specified path. Only creates new paths, will not modify existing ones.
 
 ```ts
-import { json_insert } from 'ronin/schema';
+import { json_insert } from 'blade/schema';
 
 // Usage
 await set.user(fields => ({
@@ -145,7 +145,7 @@ await set.user(fields => ({
 Concatenates a list of strings together.
 
 ```ts
-import { concat } from 'ronin/schema';
+import { concat } from 'blade/schema';
 
 // Usage
 await set.user(fields => ({
@@ -161,7 +161,7 @@ await set.user(fields => ({
 Replaces all occurrences of a substring within a string with a replacement value.
 
 ```ts
-import { replace } from 'ronin/schema';
+import { replace } from 'blade/schema';
 
 // Usage
 await set.user(fields => ({

--- a/packages/blade-better-auth/README.md
+++ b/packages/blade-better-auth/README.md
@@ -44,7 +44,7 @@ To help get started, here is that "core schema" translated to a RONIN database s
 ```ts
 // schema/index.ts
 
-import { blob, boolean, date, link, model, string } from 'ronin/schema';
+import { blob, boolean, date, link, model, string } from 'blade/schema';
 
 export const User = model({
   slug: 'user',

--- a/packages/blade-cli/src/commands/pull.ts
+++ b/packages/blade-cli/src/commands/pull.ts
@@ -89,7 +89,7 @@ export const getModelDefinitionsFileContent = async (options?: {
   const primitives = [
     ...new Set(models.flatMap((model) => model.fields.map((field) => field.type))),
   ];
-  const importStatements = `import { model, ${primitives.join(',')} } from "ronin/schema";`;
+  const importStatements = `import { model, ${primitives.join(',')} } from "blade/schema";`;
 
   const modelDefinitions = models.map((model) => {
     // We want to exclude the ronin property from the model.

--- a/packages/blade-cli/tests/utils/pull.test.ts
+++ b/packages/blade-cli/tests/utils/pull.test.ts
@@ -59,7 +59,7 @@ describe('helper', () => {
     const models = await getModelDefinitionsFileContent();
     expect(models).toBeDefined();
     expect(models).toBe(
-      formatCode(`import { boolean, model, number, string } from "ronin/schema";
+      formatCode(`import { boolean, model, number, string } from "blade/schema";
 
                 export const User = model({
                 slug: "user",
@@ -94,7 +94,7 @@ describe('helper', () => {
     const models = await getModelDefinitionsFileContent();
     expect(models).toBeDefined();
     expect(models).toBe(
-      formatCode(`import { model, string } from "ronin/schema";
+      formatCode(`import { model, string } from "blade/schema";
 
 export const User = model({
   slug: "user",
@@ -129,7 +129,7 @@ export const Post = model({
     const models = await getModelDefinitionsFileContent();
     expect(models).toBeDefined();
     expect(models).toBe(
-      formatCode(`import { model, string } from "ronin/schema";
+      formatCode(`import { model, string } from "blade/schema";
 
 export const User = model({
   slug: "user",
@@ -288,7 +288,7 @@ describe('command', () => {
     // Create a model file.
     await fs.writeFile(
       MODEL_IN_CODE_PATH,
-      `import { model } from "ronin/schema";
+      `import { model } from "blade/schema";
 
 export const User = model({
   slug: "user",
@@ -318,7 +318,7 @@ export const User = model({
     // Verify file content.
     const content = await fs.readFile(MODEL_IN_CODE_PATH, 'utf-8');
     expect(content).toBe(
-      'import { model } from "ronin/schema";\n\nexport const User = model({\n  slug: "user",\n});\n',
+      'import { model } from "blade/schema";\n\nexport const User = model({\n  slug: "user",\n});\n',
     );
   });
 });

--- a/packages/blade-client/package.json
+++ b/packages/blade-client/package.json
@@ -21,10 +21,6 @@
       "import": "./dist/types/index.js",
       "types": "./dist/types/index.d.ts"
     },
-    "./schema": {
-      "import": "./dist/schema/index.js",
-      "types": "./dist/schema/index.d.ts"
-    },
     "./utils": {
       "import": "./dist/utils/index.js",
       "types": "./dist/utils/index.d.ts"
@@ -37,9 +33,6 @@
       ],
       "types": [
         "dist/types/index.d.ts"
-      ],
-      "schema": [
-        "dist/schema/index.d.ts"
       ],
       "utils": [
         "dist/utils/index.d.ts"

--- a/packages/blade-client/src/schema/index.ts
+++ b/packages/blade-client/src/schema/index.ts
@@ -1,1 +1,0 @@
-export * from 'blade-syntax/schema';

--- a/packages/blade-syntax/src/schema/primitives.ts
+++ b/packages/blade-syntax/src/schema/primitives.ts
@@ -89,7 +89,7 @@ const primitive = <T extends ModelField['type']>(type: T) => {
  *
  * @example
  * ```ts
- * import { model, string } from 'ronin/schema';
+ * import { model, string } from 'blade/schema';
  *
  * const User = model({
  *  slug: 'user',
@@ -113,7 +113,7 @@ export const string = primitive('string');
  *
  * @example
  * ```ts
- * import { model, number } from 'ronin/schema';
+ * import { model, number } from 'blade/schema';
  *
  * const User = model({
  *  slug: 'user',
@@ -137,7 +137,7 @@ export const number = primitive('number');
  *
  * @example
  * ```ts
- * import { model, link } from 'ronin/schema';
+ * import { model, link } from 'blade/schema';
  *
  * const User = model({
  *  slug: 'user',
@@ -161,7 +161,7 @@ export const link = primitive('link');
  *
  * @example
  * ```ts
- * import { model, json } from 'ronin/schema';
+ * import { model, json } from 'blade/schema';
  *
  * const User = model({
  *  slug: 'user',
@@ -184,7 +184,7 @@ export const json = primitive('json');
  *
  * @example
  * ```ts
- * import { model, date } from 'ronin/schema';
+ * import { model, date } from 'blade/schema';
  *
  * const User = model({
  *  slug: 'user',
@@ -208,7 +208,7 @@ export const date = primitive('date');
  *
  * @example
  * ```ts
- * import { model, boolean } from 'ronin/schema';
+ * import { model, boolean } from 'blade/schema';
  *
  * const User = model({
  *  slug: 'user',
@@ -232,7 +232,7 @@ export const boolean = primitive('boolean');
  *
  * @example
  * ```ts
- * import { model, blob } from 'ronin/schema';
+ * import { model, blob } from 'blade/schema';
  *
  * const User = model({
  *  slug: 'user',

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -22,13 +22,13 @@ import { getOutputFile } from '@/private/universal/utils/paths';
 
 /**
  * Builds a Blade application.
- * 
+ *
  * @param environment - The environment for which the build should run.
  * @param [options] - Optional configuration for running the build.
  * @param [options.enableServiceWorker] - Whether service workers should be enabled.
  * @param [options.logQueries] - Whether executed queries should be logged at runtime.
  * @param [options.plugins] - Optional additional esbuild plugins to add to the build.
- * 
+ *
  * @returns An esbuild context.
  */
 export const build = async (

--- a/packages/blade/public/universal/schema.ts
+++ b/packages/blade/public/universal/schema.ts
@@ -1,1 +1,1 @@
-export * from 'ronin/schema';
+export * from 'blade-syntax/schema';


### PR DESCRIPTION
This change replaces all occurrences of `ronin/schema` with `blade/schema`, in order to simplify the syntax used when defining models in Blade.