### PR TITLE
Bundle types in main package

### DIFF
--- a/packages/blade-client/types/index.d.ts
+++ b/packages/blade-client/types/index.d.ts
@@ -1,3 +1,0 @@
-declare module 'ronin' {
-  export type Schemas = undefined;
-}

--- a/packages/blade/tsup.config.ts
+++ b/packages/blade/tsup.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   ],
   format: 'esm',
   clean: true,
-  dts: true,
+  dts: { resolve: true },
   external: ['server-list', 'client-list', 'build-meta', 'react', 'react-dom'],
   publicDir: './private/client/assets',
   treeshake: true,


### PR DESCRIPTION
Prior to this change, the exported TypeScript files of the main package were importing packages that are only available within the workspace, which caused the main package's exports to be invalid.