### PR TITLE
Enable response compression in containers

### DIFF
--- a/packages/blade/private/server/utils/polyfills.ts
+++ b/packages/blade/private/server/utils/polyfills.ts
@@ -2,8 +2,8 @@
  * Polyfills the global `CompressionStream` class for runtimes that don't support it.
  */
 export const polyfillCompressionStream = async () => {
-    // Only Bun does not offer support.
-    if (typeof Bun === 'undefined') return;
+  // Only Bun does not offer support.
+  if (typeof Bun === 'undefined') return;
 
   // We use dynamic imports to prevent `esbuild` from detecting and inlining them.
   const prefix = 'node:';

--- a/packages/blade/private/server/utils/polyfills.ts
+++ b/packages/blade/private/server/utils/polyfills.ts
@@ -1,0 +1,29 @@
+/**
+ * Polyfills the global `CompressionStream` class for runtimes that don't support it.
+ */
+export const polyfillCompressionStream = async () => {
+    // Only Bun does not offer support.
+    if (typeof Bun === 'undefined') return;
+
+  // We use dynamic imports to prevent `esbuild` from detecting and inlining them.
+  const prefix = 'node:';
+  const { Readable, Writable } = await import(`${prefix}stream`);
+  const zlib = await import(`${prefix}zlib`);
+
+  const transformMap = {
+    deflate: zlib.createDeflate,
+    'deflate-raw': zlib.createDeflateRaw,
+    gzip: zlib.createGzip,
+  };
+
+  globalThis.CompressionStream ??= class CompressionStream {
+    readable: ReadableStream;
+    writable: WritableStream;
+
+    constructor(format: keyof typeof transformMap) {
+      const handle = transformMap[format]();
+      this.readable = Readable.toWeb(handle) as unknown as ReadableStream;
+      this.writable = Writable.toWeb(handle) as unknown as WritableStream;
+    }
+  };
+};

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -48,9 +48,13 @@ const app = new Hono<{ Bindings: Bindings }>();
 // If the application runs inside a generic container instead of a specific cloud
 // provider, add support for compressing responses depending on the incoming request
 // headers, since there might not be a proxy in front that handles compression.
-if (import.meta.env.__BLADE_PROVIDER === 'edge-worker') {
+if (
+  import.meta.env.BLADE_ENV === 'production' &&
+  import.meta.env.__BLADE_PROVIDER === 'edge-worker'
+) {
   // Bun doesn't support `CompressionStream` yet, so we need to polyfill it.
   if (typeof Bun !== 'undefined') {
+    // We use dynamic imports to prevent `esbuild` from detecting and inlining them.
     const prefix = 'node:';
     const { Readable, Writable } = await import(`${prefix}stream`);
     const zlib = await import(`${prefix}zlib`);

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -48,6 +48,9 @@ const app = new Hono<{ Bindings: Bindings }>();
 // If the application runs inside a generic container instead of a specific cloud
 // provider, add support for compressing responses depending on the incoming request
 // headers, since there might not be a proxy in front that handles compression.
+//
+// If there is a proxy in front that handles compression, we assume that it wouldn't pass
+// the `Accept-Encoding` header through to the origin.
 if (
   import.meta.env.BLADE_ENV === 'production' &&
   import.meta.env.__BLADE_PROVIDER === 'edge-worker'

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -56,7 +56,7 @@ if (
   import.meta.env.BLADE_ENV === 'production' &&
   import.meta.env.__BLADE_PROVIDER === 'edge-worker'
 ) {
-  // Enable necessary polyfilly on unsupported runtimes.
+  // Enable necessary polyfills on unsupported runtimes.
   polyfillCompressionStream();
 
   // Enable the compression middleware.

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -65,7 +65,7 @@ if (import.meta.env.__BLADE_PROVIDER === 'edge-worker') {
 
       constructor(format: keyof typeof transformMap) {
         const handle = transformMap[format]();
-        this.readable = Readable.toWeb(handle);
+        this.readable = Readable.toWeb(handle) as unknown as ReadableStream;
         this.writable = Writable.toWeb(handle);
       }
     };

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -52,7 +52,7 @@ const app = new Hono<{ Bindings: Bindings }>();
 // headers, since there might not be a proxy in front that handles compression.
 if (import.meta.env.__BLADE_PROVIDER === 'edge-worker') {
   // Bun doesn't support `CompressionStream` yet, so we need to polyfill it.
-  if (typeof Bun === 'undefined') {
+  if (typeof Bun !== 'undefined') {
     const transformMap = {
       deflate: zlib.createDeflate,
       'deflate-raw': zlib.createDeflateRaw,

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -1,5 +1,3 @@
-import { Readable, Writable } from 'node:stream';
-import zlib from 'node:zlib';
 import { ClientError } from 'blade-client/utils';
 import { DML_QUERY_TYPES_WRITE, type Query, type QueryType } from 'blade-compiler';
 import { bundleId as serverBundleId } from 'build-meta';
@@ -53,6 +51,10 @@ const app = new Hono<{ Bindings: Bindings }>();
 if (import.meta.env.__BLADE_PROVIDER === 'edge-worker') {
   // Bun doesn't support `CompressionStream` yet, so we need to polyfill it.
   if (typeof Bun !== 'undefined') {
+    const prefix = 'node:';
+    const { Readable, Writable } = await import(`${prefix}stream`);
+    const zlib = await import(`${prefix}zlib`);
+
     const transformMap = {
       deflate: zlib.createDeflate,
       'deflate-raw': zlib.createDeflateRaw,

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -66,7 +66,7 @@ if (import.meta.env.__BLADE_PROVIDER === 'edge-worker') {
       constructor(format: keyof typeof transformMap) {
         const handle = transformMap[format]();
         this.readable = Readable.toWeb(handle) as unknown as ReadableStream;
-        this.writable = Writable.toWeb(handle);
+        this.writable = Writable.toWeb(handle) as unknown as WritableStream;
       }
     };
   }


### PR DESCRIPTION
This change ensures that responses are automatically compressed if Blade is run inside a container.