### PR TITLE
Use loader for Tailwind CSS styles

### DIFF
--- a/packages/blade-hono/tests/integration.test.ts
+++ b/packages/blade-hono/tests/integration.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from 'bun:test';
-import { AsyncLocalStorage } from 'node:async_hooks';
 import { createFactory } from 'hono/factory';
 import { testClient } from 'hono/testing';
 

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -80,7 +80,7 @@ if (isBuilding || isDeveloping) {
     `Building${environment === 'production' ? ' for production' : ''}`,
   );
 
-  const mainBuild = composeBuildContext(environment, {
+  const mainBuild = await composeBuildContext(environment, {
     enableServiceWorker,
     logQueries: values?.queries,
     plugins: [

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -14,7 +14,7 @@ import {
 } from '@/private/shell/constants';
 import { type ServerState, serve } from '@/private/shell/listener';
 import { cleanUp, logSpinner } from '@/private/shell/utils';
-import { build } from '@/private/shell/utils/build';
+import { composeBuildContext } from '@/private/shell/utils/build';
 
 // We want people to add BLADE to `package.json`, which, for example, ensures that
 // everyone in a team is using the same version when working on apps.
@@ -80,7 +80,7 @@ if (isBuilding || isDeveloping) {
     `Building${environment === 'production' ? ' for production' : ''}`,
   );
 
-  const mainBuild = await build(environment, {
+  const mainBuild = composeBuildContext(environment, {
     enableServiceWorker,
     logQueries: values?.queries,
     plugins: [

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -155,10 +155,7 @@ export const getClientReferenceLoader = (): esbuild.Plugin => ({
   },
 });
 
-export const getFileListLoader = (
-  projects: Array<string>,
-  filePaths?: Array<string>,
-): esbuild.Plugin => ({
+export const getFileListLoader = (filePaths?: Array<string>): esbuild.Plugin => ({
   name: 'File List Loader',
   setup(build) {
     const files: TotalFileList = new Map();
@@ -177,16 +174,6 @@ export const getFileListLoader = (
     }
     // If no virtual files were provided, crawl the directories on the file system.
     else {
-      const extraProjects = projects.slice(1);
-
-      for (let index = 0; index < extraProjects.length; index++) {
-        const project = extraProjects[index];
-        const exportName = `components${index}`;
-
-        directories.push([exportName, path.join(project, 'components')]);
-        componentDirectories.push(exportName);
-      }
-
       build.onStart(async () => {
         await Promise.all(
           directories.map(async ([directoryName, directoryPath]) => {

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -342,7 +342,7 @@ export const getTailwindLoader = (
       candidates = [];
     });
 
-    build.onLoad({ filter: /\.(?:tsx|jsx)$/ }, async (args) => {
+    build.onResolve({ filter: /\.(?:tsx|jsx)$/ }, async (args) => {
       const content = await readFile(args.path, 'utf8');
       const extension = path.extname(args.path).slice(1);
       const newCandidates = scanner.getCandidatesWithPositions({ content, extension });

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -364,36 +364,3 @@ export const getTailwindLoader = (
     });
   },
 });
-
-// TODO: Move this into a config file or plugin.
-//
-// This ensures that no unnecessary localizations are included in the client bundle,
-// which would otherwise increase the bundle size.
-//
-// https://github.com/adobe/react-spectrum/blob/1dcc8705115364a2c2ead2ececae8883dd6e9d07/packages/dev/optimize-locales-plugin/LocalesPlugin.js
-export const getReactAriaLoader = (): esbuild.Plugin => ({
-  name: 'React Aria Loader',
-  setup(build) {
-    build.onLoad(
-      {
-        filter:
-          /(@react-stately|@react-aria|@react-spectrum|react-aria-components)\/(.*)\/[a-zA-Z]{2}-[a-zA-Z]{2}\.(js|mjs)$/,
-      },
-      async (source) => {
-        const { name } = path.parse(source.path);
-
-        if (name === 'en-US') {
-          return {
-            contents: await readFile(source.path),
-            loader: 'js',
-          };
-        }
-
-        return {
-          contents: 'const removedLocale = undefined;\nexport default removedLocale;',
-          loader: 'js',
-        };
-      },
-    );
-  },
-});

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -322,7 +322,7 @@ export const getMetaLoader = (virtual: boolean): esbuild.Plugin => ({
 export const getTailwindLoader = (
   environment: 'development' | 'production',
 ): esbuild.Plugin => ({
-  name: 'Init Loader',
+  name: 'Tailwind CSS Loader',
   setup(build) {
     let compiler: Awaited<ReturnType<typeof compileTailwind>>;
     let candidates: Array<string> = [];

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -43,7 +43,7 @@ export const composeBuildContext = (
     plugins?: Array<esbuild.Plugin>;
     filePaths?: Array<string>;
   },
-): esbuild.BuildContext => {
+): Promise<esbuild.BuildContext> => {
   const provider = getProvider();
   const virtual = Boolean(options?.filePaths);
 

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -14,6 +14,7 @@ import {
   getMdxLoader,
   getMetaLoader,
   getProviderLoader,
+  getReactAriaLoader,
   getTailwindLoader,
 } from '@/private/shell/loaders';
 import { type VirtualFile, composeEnvironmentVariables } from '@/private/shell/utils';
@@ -83,6 +84,7 @@ export const composeBuildContext = (
     plugins: [
       getFileListLoader(options?.virtualFiles),
       getMdxLoader(environment),
+      getReactAriaLoader(),
       getClientReferenceLoader(),
       getTailwindLoader(environment),
       getMetaLoader(Boolean(options?.virtualFiles)),

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -16,6 +16,7 @@ import {
   getMetaLoader,
   getProviderLoader,
   getReactAriaLoader,
+  getTailwindLoader,
 } from '@/private/shell/loaders';
 import { composeEnvironmentVariables, exists } from '@/private/shell/utils';
 import { getProvider } from '@/private/shell/utils/providers';
@@ -103,6 +104,7 @@ export const build = async (
       getMdxLoader(environment),
       getReactAriaLoader(),
       getClientReferenceLoader(),
+      getTailwindLoader(environment),
       getMetaLoader(environment, projects, virtual),
       getProviderLoader(environment, provider),
 

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -14,7 +14,6 @@ import {
   getMdxLoader,
   getMetaLoader,
   getProviderLoader,
-  getReactAriaLoader,
   getTailwindLoader,
 } from '@/private/shell/loaders';
 import { type VirtualFile, composeEnvironmentVariables } from '@/private/shell/utils';
@@ -84,7 +83,6 @@ export const composeBuildContext = (
     plugins: [
       getFileListLoader(options?.virtualFiles),
       getMdxLoader(environment),
-      getReactAriaLoader(),
       getClientReferenceLoader(),
       getTailwindLoader(environment),
       getMetaLoader(Boolean(options?.virtualFiles)),

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import * as esbuild from 'esbuild';
 
@@ -18,7 +17,7 @@ import {
   getReactAriaLoader,
   getTailwindLoader,
 } from '@/private/shell/loaders';
-import { composeEnvironmentVariables } from '@/private/shell/utils';
+import { type VirtualFile, composeEnvironmentVariables } from '@/private/shell/utils';
 import { getProvider } from '@/private/shell/utils/providers';
 import { getOutputFile } from '@/private/universal/utils/paths';
 
@@ -41,11 +40,10 @@ export const composeBuildContext = (
     enableServiceWorker?: boolean;
     logQueries?: boolean;
     plugins?: Array<esbuild.Plugin>;
-    filePaths?: Array<string>;
+    virtualFiles?: Array<VirtualFile>;
   },
 ): Promise<esbuild.BuildContext> => {
   const provider = getProvider();
-  const virtual = Boolean(options?.filePaths);
 
   const entryPoints: esbuild.BuildOptions['entryPoints'] = [
     {
@@ -72,7 +70,7 @@ export const composeBuildContext = (
     bundle: true,
 
     // Return the files in memory if a list of source file paths was provided.
-    write: !virtual,
+    write: !options?.virtualFiles,
 
     platform: provider === 'vercel' ? 'node' : 'browser',
     format: 'esm',
@@ -84,12 +82,12 @@ export const composeBuildContext = (
     external: ['node:events'],
 
     plugins: [
-      getFileListLoader(options?.filePaths),
+      getFileListLoader(options?.virtualFiles),
       getMdxLoader(environment),
       getReactAriaLoader(),
       getClientReferenceLoader(),
       getTailwindLoader(environment),
-      getMetaLoader(virtual),
+      getMetaLoader(Boolean(options?.virtualFiles)),
       getProviderLoader(environment, provider),
 
       ...(options?.plugins || []),

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -105,7 +105,7 @@ export const build = async (
       getReactAriaLoader(),
       getClientReferenceLoader(),
       getTailwindLoader(environment),
-      getMetaLoader(environment, projects, virtual),
+      getMetaLoader(virtual),
       getProviderLoader(environment, provider),
 
       ...(options?.plugins || []),

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -1,4 +1,3 @@
-import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import * as esbuild from 'esbuild';
 

--- a/packages/blade/private/shell/utils/index.ts
+++ b/packages/blade/private/shell/utils/index.ts
@@ -1,4 +1,4 @@
-import { constants, access, readFile, readdir, rm } from 'node:fs/promises';
+import { constants, access, readdir, rm } from 'node:fs/promises';
 import path from 'node:path';
 import type { TSESTree } from '@typescript-eslint/typescript-estree';
 import ora from 'ora';
@@ -34,19 +34,19 @@ export const crawlDirectory = async (directoryPath: string): Promise<FileList> =
 /**
  * Crawls a directory that only exists virtually (in memory) and not on the file system.
  *
- * @param virtualFiles - The entire list of virtual files.
+ * @param filePaths - The entire list of virtual files.
  * @param directoryName — The directory within the list of files that should be crawled.
  *
  * @returns A list of nested files and directories.
  */
 export const crawlVirtualDirectory = (
-  virtualFiles: Array<VirtualFile>,
+  filePaths: string[],
   directoryName: string,
 ): FileList => {
   const entries: FileList = [];
   const seenDirs = new Set<string>();
 
-  for (const { path: filePath } of virtualFiles) {
+  for (const filePath of filePaths) {
     // Only include items under the specified directory.
     if (!filePath.startsWith(`${directoryName}/`)) continue;
     const parts = filePath.split('/');
@@ -266,20 +266,3 @@ export const exists = (path: string) =>
   access(path, constants.F_OK)
     .then(() => true)
     .catch(() => false);
-
-export interface VirtualFile {
-  /**
-   * The path of the file, relative to the project root. For example, when providing a
-   * page, its path might be `pages/index.tsx`.
-   */
-  path: string;
-  /** The content of the file, as a string. */
-  content: string;
-}
-
-export const readVirtualFile = (path: string, virtualFiles?: Array<VirtualFile>) => {
-  if (!virtualFiles) return readFile(path, 'utf8');
-  const file = virtualFiles.find((item) => item.path === path);
-  if (!file) throw new Error(`File "${path}" not found.`);
-  return file.content;
-};

--- a/packages/blade/public/universal/utils.ts
+++ b/packages/blade/public/universal/utils.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import type { Loader, Message, OutputFile } from 'esbuild';
 
 import { nodePath, sourceDirPath } from '@/private/shell/constants';
-import { build as buildContext } from '@/private/shell/utils/build';
+import { composeBuildContext } from '@/private/shell/utils/build';
 
 interface SourceFile {
   /**
@@ -34,7 +34,7 @@ interface BuildOutput {
 export const build = async (config: BuildConfig): Promise<BuildOutput> => {
   const environment = config?.environment || 'development';
 
-  const mainBuild = await buildContext(environment, {
+  const mainBuild = composeBuildContext(environment, {
     // Normalize file paths, so that all of them are absolute.
     filePaths: config.sourceFiles.map(({ path }) => {
       if (path.startsWith('./')) return path.slice(1);

--- a/packages/blade/public/universal/utils.ts
+++ b/packages/blade/public/universal/utils.ts
@@ -34,7 +34,7 @@ interface BuildOutput {
 export const build = async (config: BuildConfig): Promise<BuildOutput> => {
   const environment = config?.environment || 'development';
 
-  const mainBuild = composeBuildContext(environment, {
+  const mainBuild = await composeBuildContext(environment, {
     // Normalize file paths, so that all of them are absolute.
     filePaths: config.sourceFiles.map(({ path }) => {
       if (path.startsWith('./')) return path.slice(1);

--- a/packages/blade/public/universal/utils.ts
+++ b/packages/blade/public/universal/utils.ts
@@ -2,19 +2,11 @@ import path from 'node:path';
 import type { Loader, Message, OutputFile } from 'esbuild';
 
 import { nodePath, sourceDirPath } from '@/private/shell/constants';
+import type { VirtualFile } from '@/private/shell/utils';
 import { composeBuildContext } from '@/private/shell/utils/build';
 
-interface SourceFile {
-  /**
-   * The path of the file, relative to the project root. For example, when providing a
-   * page, its path might be `pages/index.tsx`.
-   */
-  path: string;
-  /** The content of the file, as a string. */
-  content: string;
-}
 interface BuildConfig {
-  sourceFiles: Array<SourceFile>;
+  sourceFiles: Array<VirtualFile>;
   environment?: 'development' | 'production';
 }
 
@@ -36,10 +28,14 @@ export const build = async (config: BuildConfig): Promise<BuildOutput> => {
 
   const mainBuild = await composeBuildContext(environment, {
     // Normalize file paths, so that all of them are absolute.
-    filePaths: config.sourceFiles.map(({ path }) => {
-      if (path.startsWith('./')) return path.slice(1);
-      if (path.startsWith('/')) return path;
-      return `/${path}`;
+    virtualFiles: config.sourceFiles.map(({ path, content }) => {
+      const newPath = path.startsWith('./')
+        ? path.slice(1)
+        : path.startsWith('/')
+          ? path
+          : `/${path}`;
+
+      return { path: newPath, content };
     }),
     plugins: [
       {


### PR DESCRIPTION
This change adds a new `esbuild` loader for Tailwind CSS, in order to tightly integrate Tailwind CSS into the build.