### PR TITLE
Fix documentation navigation link elements

### DIFF
--- a/docs/components/nav.tsx
+++ b/docs/components/nav.tsx
@@ -40,7 +40,7 @@ export const Nav = ({
                     'bg-accent text-primary': item.href === location.pathname,
                   },
                 )}>
-                <span>{item.name}</span>
+                <a>{item.name}</a>
               </Link>
             ))}
           </div>


### PR DESCRIPTION
This change fixes the issue outlined in #362 where links in the sidebar navigation were not correctly being detected by vimari. This was due to a small bug / oversight where the `Link`s for this component were wrapping the elements in `span` instead of anchor's (`a`).