### PR TITLE
Improve documentation page transitions

### DIFF
--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -120,7 +120,7 @@ const DocsLayout = ({
 
   useMetadata({
     htmlClassName: cn(
-      'scroll-smooth antialiased',
+      'antialiased',
       theme && ['dark', 'light'].includes(theme) ? theme : undefined,
     ),
     title,


### PR DESCRIPTION
This change fixes the issue outlined in #368 where transitioning pages would use the `scroll-smooth` class to apply some easing transitions. This has now been removed.