### PR TITLE
Avoid unnecessary JS<>Rust switches

### DIFF
--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -168,6 +168,8 @@ export const getFileListLoader = (
     ['components', path.join(process.cwd(), 'components')],
   ];
 
+  const filter = { id: /^(?:server-list|client-list)$/ };
+
   return {
     name: 'File List Loader',
     async buildStart() {
@@ -191,22 +193,21 @@ export const getFileListLoader = (
         );
       }
     },
-    resolveId(source) {
-      if (source === 'server-list') return '\u0000server-list.tsx';
-      if (source === 'client-list') return '\u0000client-list.tsx';
-
-      return null;
+    resolveId: {
+      filter,
+      handler(source) {
+        return source;
+      },
     },
-    async load(id) {
-      if (id === '\u0000server-list.tsx') {
-        return getFileList(files, ['pages', 'triggers'], await exists(routerInputFile));
-      }
+    load: {
+      filter,
+      async handler(id) {
+        if (id === 'server-list') {
+          return getFileList(files, ['pages', 'triggers'], await exists(routerInputFile));
+        }
 
-      if (id === '\u0000client-list.tsx') {
         return getFileList(files, ['components']);
-      }
-
-      return null;
+      },
     },
   };
 };

--- a/packages/blade/public/universal/utils.ts
+++ b/packages/blade/public/universal/utils.ts
@@ -2,6 +2,12 @@ import path from 'node:path';
 
 import { type VirtualFileItem, composeBuildContext } from '@/private/shell/utils/build';
 
+const makePathAbsolute = (input: string) => {
+  if (input.startsWith('./')) return input.slice(1);
+  if (input.startsWith('/')) return input;
+  return `/${input}`;
+};
+
 interface BuildConfig {
   sourceFiles: Array<VirtualFileItem>;
   environment?: 'development' | 'production';
@@ -20,12 +26,7 @@ export const build = async (
   const environment = config?.environment || 'development';
 
   const virtualFiles = config.sourceFiles.map(({ path, content }) => {
-    const newPath = path.startsWith('./')
-      ? path.slice(1)
-      : path.startsWith('/')
-        ? path
-        : `/${path}`;
-    return { path: newPath, content };
+    return { path: makePathAbsolute(path), content };
   });
 
   return composeBuildContext(environment, {


### PR DESCRIPTION
This change ensures that our Rust compiler doesn't unnecessarily switch to JS, which is expensive, since JS is slower.