### PR TITLE
Prevent revalidation flickers during streaming

### DIFF
--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -12,12 +12,9 @@ import {
   getRequestLanguages,
   getRequestUserAgent,
 } from '@/private/server/utils/request-context';
-import renderReactTree, {
-  flushSession,
-  type Collected,
-} from '@/private/server/worker/tree';
+import renderReactTree, { flushSession } from '@/private/server/worker/tree';
 import { prepareTriggers } from '@/private/server/worker/triggers';
-import type { PageFetchingOptions } from '@/private/universal/types/util';
+import type { PageFetchingOptions, QueryItemWrite } from '@/private/universal/types/util';
 import { CLIENT_ASSET_PREFIX, CUSTOM_HEADERS } from '@/private/universal/utils/constants';
 import { TriggerError } from '@/public/server/utils/errors';
 
@@ -241,7 +238,7 @@ app.post('*', async (c) => {
     }
   }
 
-  let queries: Collected['queries'] | undefined;
+  let queries: Array<QueryItemWrite> | undefined;
 
   if (options?.queries) {
     queries = options.queries;

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -456,7 +456,7 @@ export const flushSession = async (
   headers: Headers,
   correctBundle: boolean,
   options?: {
-    queries?: Collected['queries'];
+    queries?: Array<QueryItemWrite>;
     repeat?: boolean;
   },
 ): Promise<void> => {
@@ -489,9 +489,16 @@ export const flushSession = async (
       },
       options?.queries
         ? {
-            jwts: {},
+            // Do not pass `options.queries` directly here, since it will get modified
+            // in place and we don't want to resume the results of queries.
+            queries: options.queries.map(({ query, database, hookHash }) => ({
+              type: 'write',
+              query,
+              database,
+              hookHash,
+            })),
             metadata: {},
-            queries: options.queries,
+            jwts: {},
           }
         : undefined,
     );


### PR DESCRIPTION
This change ensures that the UI doesn't flicker while the server is streaming changes to the client.