### PR TITLE
Ensure reliable UI flushing

### DIFF
--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -523,7 +523,7 @@ export const flushSession = async (
   // flushing yet another update.
   if (options?.repeat) {
     await sleep(5000);
-    return flushSession(stream, url, headers, true, options);
+    return flushSession(stream, url, headers, true, { repeat: options.repeat });
   }
 
   // If no repetition is desired, signal the end of the stream to the client. But only if


### PR DESCRIPTION
This change was missing from https://github.com/ronin-co/blade/pull/382 / https://github.com/ronin-co/blade/pull/379 and ensures that the UI is flushed correctly from the server.