### PR TITLE
Fix `login` command base URL

### DIFF
--- a/packages/blade-cli/src/commands/login.ts
+++ b/packages/blade-cli/src/commands/login.ts
@@ -28,7 +28,7 @@ const logIn = async (appToken?: string, exit = true): Promise<string | undefined
   const port = await getPort();
   const server = http.createServer().listen(port);
 
-  const baseURL = new URL('https://ronin.co/actions/auth/cli');
+  const baseURL = new URL('https://studio.ronin.co/actions/auth/cli');
 
   const currentHost = `http://localhost:${port}`;
   const initURL = new URL(baseURL);


### PR DESCRIPTION
This PR fixes the base URL provided when using the `login` sub-command by correctly pointing to the new RONIN Studio API endpoint.