### PR TITLE
Correctly parse client components

### DIFF
--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -60,7 +60,7 @@ export const getClientReferenceLoader = (): RolldownPlugin => ({
       const ast = this.parse(contents, {
         lang: extension,
         sourceType: 'module',
-        astType: 'js',
+        astType: 'ts',
         range: true,
       });
 


### PR DESCRIPTION
This changes prevents Blade from incorrectly recognizing type exports as runtime code exports, which is a bug that is currently blocking the deployments of our docs.