### PR TITLE
Preload universal bundle code

### DIFF
--- a/packages/blade/private/client/utils/page.ts
+++ b/packages/blade/private/client/utils/page.ts
@@ -20,7 +20,7 @@ type PreloadableAsset = Exclude<Asset['type'], 'worker'>;
  * @returns A promise that resolves once the asset is downloaded.
  */
 const loadResource = async (bundleId: string, type: PreloadableAsset) => {
-  const extensions: Record<PreloadableAsset, string> = {
+  const extensions: Record<PreloadableAsset, 'js' | 'css'> = {
     'main-css': 'css',
     'main-js': 'js',
     shared: 'js',

--- a/packages/blade/private/client/utils/page.ts
+++ b/packages/blade/private/client/utils/page.ts
@@ -29,7 +29,7 @@ const loadResource = async (bundleId: string, type: PreloadableAsset) => {
   const extension = extensions[type];
 
   return new Promise((resolve, reject) => {
-    const link = document.createElement('link');
+    const link = document.createElement('link') as HTMLLinkElement;
 
     link.rel = 'preload';
     link.as = extension === 'css' ? 'style' : 'script';

--- a/packages/blade/private/client/utils/page.ts
+++ b/packages/blade/private/client/utils/page.ts
@@ -26,14 +26,16 @@ const loadResource = async (bundleId: string, type: PreloadableAsset) => {
     shared: 'js',
   };
 
+  const extension = extensions[type];
+
   return new Promise((resolve, reject) => {
     const link = document.createElement('link');
 
     link.rel = 'preload';
-    link.as = type;
+    link.as = extension === 'css' ? 'style' : 'script';
     link.onload = resolve;
     link.onerror = reject;
-    link.href = `/${getOutputFile(bundleId, extensions[type], type === 'shared')}`;
+    link.href = `/${getOutputFile(bundleId, extension, type === 'shared')}`;
 
     document.head.appendChild(link);
   });

--- a/packages/blade/private/server/components/root.tsx
+++ b/packages/blade/private/server/components/root.tsx
@@ -95,6 +95,7 @@ const Root = ({ children, serverContext }: RootProps) => {
             case 'worker':
               return (
                 <link
+                  key={type}
                   rel="prefetch"
                   href={source}
                   as="script"

--- a/packages/blade/private/server/components/root.tsx
+++ b/packages/blade/private/server/components/root.tsx
@@ -92,10 +92,20 @@ const Root = ({ children, serverContext }: RootProps) => {
                 />
               );
             case 'shared':
+              return (
+                <link
+                  key="shared"
+                  // High priority fetching.
+                  rel="preload"
+                  href={source}
+                  as="script"
+                />
+              );
             case 'worker':
               return (
                 <link
-                  key={type}
+                  key="worker"
+                  // Low priority fetching.
                   rel="prefetch"
                   href={source}
                   as="script"

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -123,10 +123,7 @@ export const composeBuildContext = async (
           return '[name].js';
         },
         assetFileNames: getOutputFile(bundleId, 'css'),
-        chunkFileNames: () => {
-          const chunkId = generateUniqueId();
-          return getOutputFile(chunkId, 'js', true);
-        },
+        chunkFileNames: getOutputFile(bundleId, 'js', true),
       };
 
       return options?.virtualFiles

--- a/packages/blade/private/universal/types/util.ts
+++ b/packages/blade/private/universal/types/util.ts
@@ -44,7 +44,7 @@ export interface QueryItemWrite extends QueryItemBase {
 }
 
 export type Asset = {
-  type: 'css' | 'js' | 'worker';
+  type: 'main-js' | 'main-css' | 'shared' | 'worker';
   source: string;
 };
 

--- a/packages/blade/private/universal/utils/paths.ts
+++ b/packages/blade/private/universal/utils/paths.ts
@@ -43,6 +43,6 @@ export const populatePathSegments = (
   return href === '/' ? href : href.replace(/\/$/, '');
 };
 
-export const getOutputFile = (bundleId: string, type: string, chunk?: boolean) => {
-  return `${CLIENT_ASSET_PREFIX}/${chunk ? 'chunk' : 'main'}.${bundleId}.${type}`;
+export const getOutputFile = (bundleId: string, ext: 'js' | 'css', chunk?: boolean) => {
+  return `${CLIENT_ASSET_PREFIX}/${chunk ? 'chunk' : 'main'}.${bundleId}.${ext}`;
 };


### PR DESCRIPTION
This change ensures that the client preloads the bundle chunk that is shared between client and server, instead of waiting for the main client entry point to download it (the latter is slower).