### PR TITLE
Add `blade login` command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/blade": {
       "name": "blade",
-      "version": "3.9.1",
+      "version": "3.10.6",
       "bin": {
         "blade": "./dist/private/shell/index.js",
       },
@@ -39,6 +39,7 @@
         "@vercel/functions": "2.0.2",
         "@vitest/coverage-v8": "2.1.8",
         "async-retry": "1.3.3",
+        "blade-cli": "workspace:*",
         "blade-client": "workspace:*",
         "blade-compiler": "workspace:*",
         "blade-syntax": "workspace:*",
@@ -63,7 +64,7 @@
     },
     "packages/blade-better-auth": {
       "name": "blade-better-auth",
-      "version": "3.9.1",
+      "version": "3.10.6",
       "dependencies": {
         "better-auth": "1.2.5",
       },
@@ -81,7 +82,7 @@
     },
     "packages/blade-cli": {
       "name": "blade-cli",
-      "version": "3.9.1",
+      "version": "3.10.6",
       "dependencies": {
         "@dprint/formatter": "0.4.1",
         "@dprint/typescript": "0.93.3",
@@ -113,7 +114,7 @@
     },
     "packages/blade-client": {
       "name": "blade-client",
-      "version": "3.9.1",
+      "version": "3.10.6",
       "bin": {
         "ronin": "./dist/bin/index.js",
       },
@@ -132,7 +133,7 @@
     },
     "packages/blade-codegen": {
       "name": "blade-codegen",
-      "version": "3.9.1",
+      "version": "3.10.6",
       "dependencies": {
         "typescript": "5.7.3",
       },
@@ -146,7 +147,7 @@
     },
     "packages/blade-compiler": {
       "name": "blade-compiler",
-      "version": "3.9.1",
+      "version": "3.10.6",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.14",
@@ -160,7 +161,7 @@
     },
     "packages/blade-hono": {
       "name": "blade-hono",
-      "version": "3.9.1",
+      "version": "3.10.6",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.18",
@@ -176,7 +177,7 @@
     },
     "packages/blade-syntax": {
       "name": "blade-syntax",
-      "version": "3.9.1",
+      "version": "3.10.6",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -188,7 +189,7 @@
     },
     "packages/create-blade": {
       "name": "create-blade",
-      "version": "3.9.1",
+      "version": "3.10.6",
       "bin": {
         "create-blade": "./dist/index.js",
       },

--- a/packages/blade-cli/package.json
+++ b/packages/blade-cli/package.json
@@ -8,6 +8,26 @@
   "files": [
     "dist"
   ],
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./commands/login": {
+      "import": "./dist/commands/login.js",
+      "types": "./dist/commands/login.d.ts"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "dist/index.d.ts"
+      ],
+      "commands/login": [
+        "dist/commands/login.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "lint": "bun run --bun lint:tsc && bun run --bun lint:biome",
     "lint:biome": "biome check",

--- a/packages/blade-cli/package.json
+++ b/packages/blade-cli/package.json
@@ -14,7 +14,7 @@
     "lint:tsc": "tsc --pretty",
     "format": "biome check --write && biome format --write",
     "test": "bun test",
-    "build": "tsup ./src/index.ts --dts --format esm"
+    "build": "tsup"
   },
   "keywords": [
     "database",

--- a/packages/blade-cli/src/index.ts
+++ b/packages/blade-cli/src/index.ts
@@ -122,3 +122,10 @@ export const run = async (config: { version: string }): Promise<void> => {
 };
 
 export default run;
+
+export const commands = {
+  apply,
+  diff,
+  init: initializeProject,
+  login: logIn,
+};

--- a/packages/blade-cli/src/index.ts
+++ b/packages/blade-cli/src/index.ts
@@ -122,10 +122,3 @@ export const run = async (config: { version: string }): Promise<void> => {
 };
 
 export default run;
-
-export const commands = {
-  apply,
-  diff,
-  init: initializeProject,
-  login: logIn,
-};

--- a/packages/blade-cli/tsup.config.json
+++ b/packages/blade-cli/tsup.config.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://cdn.jsdelivr.net/npm/tsup/schema.json",
+  "dts": true,
+  "entry": {
+    "index": "./src/index.ts"
+  },
+  "format": "esm"
+}

--- a/packages/blade-cli/tsup.config.json
+++ b/packages/blade-cli/tsup.config.json
@@ -2,7 +2,8 @@
   "$schema": "https://cdn.jsdelivr.net/npm/tsup/schema.json",
   "dts": true,
   "entry": {
-    "index": "./src/index.ts"
+    "index": "./src/index.ts",
+    "commands/login": "./src/commands/login.ts"
   },
   "format": "esm"
 }

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -80,6 +80,7 @@
     "@vercel/functions": "2.0.2",
     "@vitest/coverage-v8": "2.1.8",
     "async-retry": "1.3.3",
+    "blade-cli": "workspace:*",
     "blade-client": "workspace:*",
     "blade-compiler": "workspace:*",
     "blade-syntax": "workspace:*",

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -7,11 +7,7 @@ import chokidar, { type EmitArgsWithName } from 'chokidar';
 import dotenv from 'dotenv';
 import getPort, { portNumbers } from 'get-port';
 
-import {
-  defaultDeploymentProvider,
-  loggingPrefixes,
-  outputDirectory,
-} from '@/private/shell/constants';
+import { defaultDeploymentProvider, outputDirectory } from '@/private/shell/constants';
 import { type ServerState, serve } from '@/private/shell/listener';
 import { cleanUp, logSpinner } from '@/private/shell/utils';
 import { composeBuildContext } from '@/private/shell/utils/build';

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -3,6 +3,7 @@
 import os from 'node:os';
 import path from 'node:path';
 import { parseArgs } from 'node:util';
+import login from 'blade-cli/commands/login';
 import chokidar, { type EmitArgsWithName } from 'chokidar';
 import dotenv from 'dotenv';
 import getPort, { portNumbers } from 'get-port';
@@ -40,8 +41,21 @@ const { values, positionals } = parseArgs({
   allowPositionals: true,
 });
 
-const isBuilding = positionals.includes('build');
-const isServing = positionals.includes('serve');
+// This ensures that people can accidentally type uppercase letters and still get the
+// command they are looking for.
+const normalizedPositionals = positionals.map((positional) => positional.toLowerCase());
+
+// If this environment variable is provided, the CLI will authenticate as an app for a
+// particular space instead of authenticating as an account. This is especially useful
+// in CI, which must be independent of individual people.
+const appToken = process.env['RONIN_TOKEN'];
+
+// `blade login` command
+const isLoggingIn = normalizedPositionals.includes('login');
+if (isLoggingIn) await login(appToken, true);
+
+const isBuilding = normalizedPositionals.includes('build');
+const isServing = normalizedPositionals.includes('serve');
 const isDeveloping = !isBuilding && !isServing;
 const enableServiceWorker = values.sw;
 

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -16,15 +16,6 @@ import { type ServerState, serve } from '@/private/shell/listener';
 import { cleanUp, logSpinner } from '@/private/shell/utils';
 import { composeBuildContext } from '@/private/shell/utils/build';
 
-// We want people to add BLADE to `package.json`, which, for example, ensures that
-// everyone in a team is using the same version when working on apps.
-if (!process.env['npm_lifecycle_event']) {
-  console.error(
-    `${loggingPrefixes.error} The package must be installed locally, not globally.`,
-  );
-  process.exit(0);
-}
-
 // Load the `.env` file.
 dotenv.config();
 


### PR DESCRIPTION
As part of an on-going effort to add feature parity between `blade-client` and `blade` itself, the `blade` package has been updated to handle the `blade login` sub command.