### PR TITLE
Manually create `.gitignore` files for project templates

### DIFF
--- a/packages/create-blade/src/index.ts
+++ b/packages/create-blade/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync } from 'node:fs';
-import { cp } from 'node:fs/promises';
+import { cp, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
@@ -101,6 +101,18 @@ async function main(): Promise<void> {
       errorOnExist: true,
       recursive: true,
     });
+
+    // Note: npm ignores all `.gitignore` files by default. But even when explicitly told
+    // to include them, it still ignores them. So we need to create this file manually.
+    await writeFile(
+      path.join(directory.target, '.gitignore'),
+      `# Build output
+.blade
+
+# Dependencies
+node_modules`,
+    );
+
     logSpinner('Successfully created example app').succeed();
   } catch (error) {
     logSpinner('Failed to create example app').fail();

--- a/packages/create-blade/templates/advanced/.gitignore
+++ b/packages/create-blade/templates/advanced/.gitignore
@@ -1,5 +1,0 @@
-# Build output
-.blade
-
-# Dependencies
-node_modules

--- a/packages/create-blade/templates/basic/.gitignore
+++ b/packages/create-blade/templates/basic/.gitignore
@@ -1,5 +1,0 @@
-# Build output
-.blade
-
-# Dependencies
-node_modules


### PR DESCRIPTION
This change fixes a small issue with the `create-blade` package where all `.gitignore` files are being ignored when packaging the package. Instead we now create the file pragmatically, since attempts to explicitly include the file proved unsuccessful.