### PR TITLE
Improved export compatibility

### DIFF
--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -21,8 +21,9 @@
     "dev": "unbuild --watch"
   },
   "exports": {
-    "./client/": "./dist/public/client/",
-    "./server/": "./dist/public/server/",
+    "./client/*": "./dist/public/client/*.js",
+    "./server/*": "./dist/public/server/*.js",
+    "./server/utils/*": "./dist/public/server/utils/*.js",
     "./hooks": "./dist/public/universal/hooks.js",
     "./schema": "./dist/public/universal/schema.js",
     "./types": "./dist/public/universal/types.js",


### PR DESCRIPTION
This change ensures that our exports are compatible with the [Node.js spec](https://nodejs.org/api/packages.html#package-entry-points) for `exports`.

Our previous configuration worked with many tools, but seemingly isn't spec compliant, so it caused [resolve-from](https://www.npmjs.com/package/resolve-from) (which uses Node.js internals for resolving) to not find the exports.