### PR TITLE
Enable client components for in-memory builds

### DIFF
--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -46,7 +46,7 @@ export const getClientReferenceLoader = (): RolldownPlugin => ({
     handler(code, id) {
       const extension = path.extname(id).slice(1) as 'ts' | 'tsx' | 'js' | 'jsx';
       const rawContents = code;
-      const relativeSourcePath = path.relative(process.cwd(), id.replace(/^\0+/, ''));
+      const relativeSourcePath = path.relative(process.cwd(), id).replace('virtual:/', '');
       const chunkId = generateUniqueId();
 
       const contents = [


### PR DESCRIPTION
This change makes it possible to use client components with in-memory builds.