### PR TITLE
Let Blade compile queries locally

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/blade": {
       "name": "blade",
-      "version": "3.11.1",
+      "version": "3.12.1",
       "bin": {
         "blade": "./dist/private/shell/index.js",
       },
@@ -66,7 +66,7 @@
     },
     "packages/blade-better-auth": {
       "name": "blade-better-auth",
-      "version": "3.11.1",
+      "version": "3.12.1",
       "dependencies": {
         "better-auth": "1.2.5",
       },
@@ -84,7 +84,7 @@
     },
     "packages/blade-cli": {
       "name": "blade-cli",
-      "version": "3.11.1",
+      "version": "3.12.1",
       "dependencies": {
         "@dprint/formatter": "0.4.1",
         "@dprint/typescript": "0.93.3",
@@ -116,7 +116,7 @@
     },
     "packages/blade-client": {
       "name": "blade-client",
-      "version": "3.11.1",
+      "version": "3.12.1",
       "bin": {
         "ronin": "./dist/bin/index.js",
       },
@@ -129,13 +129,14 @@
         "blade-cli": "workspace:*",
         "blade-compiler": "workspace:*",
         "blade-syntax": "workspace:*",
+        "hive": "1.0.8",
         "tsup": "8.5.0",
         "typescript": "5.8.3",
       },
     },
     "packages/blade-codegen": {
       "name": "blade-codegen",
-      "version": "3.11.1",
+      "version": "3.12.1",
       "dependencies": {
         "typescript": "5.7.3",
       },
@@ -149,7 +150,7 @@
     },
     "packages/blade-compiler": {
       "name": "blade-compiler",
-      "version": "3.11.1",
+      "version": "3.12.1",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.14",
@@ -163,7 +164,7 @@
     },
     "packages/blade-hono": {
       "name": "blade-hono",
-      "version": "3.11.1",
+      "version": "3.12.1",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.18",
@@ -179,7 +180,7 @@
     },
     "packages/blade-syntax": {
       "name": "blade-syntax",
-      "version": "3.11.1",
+      "version": "3.12.1",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -191,7 +192,7 @@
     },
     "packages/create-blade": {
       "name": "create-blade",
-      "version": "3.11.1",
+      "version": "3.12.1",
       "bin": {
         "create-blade": "./dist/index.js",
       },
@@ -869,6 +870,8 @@
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
+
+    "hive": ["hive@1.0.8", "", { "dependencies": { "hono": "4.8.4", "zod": "3.25.75" }, "peerDependencies": { "typescript": "^5" } }, "sha512-wHyHDadWUzN5awl29oIEELgxKRzwOSJBYYG4fiyDeI2rdLkv3e3LymzuZszyT5MaF6L2ghDIAF3FXiz0+MzfNw=="],
 
     "hono": ["hono@4.7.11", "", {}, "sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ=="],
 
@@ -1573,6 +1576,10 @@
     "execa/onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
 
     "gradient-string/chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
+
+    "hive/hono": ["hono@4.8.4", "", {}, "sha512-KOIBp1+iUs0HrKztM4EHiB2UtzZDTBihDtOF5K6+WaJjCPeaW4Q92R8j63jOhvJI5+tZSMuKD9REVEXXY9illg=="],
+
+    "hive/zod": ["zod@3.25.75", "", {}, "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg=="],
 
     "log-symbols/chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
 

--- a/packages/blade-client/package.json
+++ b/packages/blade-client/package.json
@@ -72,6 +72,7 @@
     "blade-cli": "workspace:*",
     "blade-compiler": "workspace:*",
     "blade-syntax": "workspace:*",
+    "hive": "1.0.8",
     "tsup": "8.5.0",
     "typescript": "5.8.3"
   }

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -94,7 +94,12 @@ export const runQueries = async <T extends ResultRecord>(
       return result;
     });
 
+    // The `transaction.formatResults` logic of the query compiler (which is invoked
+    // above), purposefully only formats results in a network-serializable manner. The
+    // formatting logic below applies formatting that is specific to the JavaScript
+    // environment, such as using `Date` instances for timestamps.
     const finalResults = formatResults<T>(usableResults as Array<Result<T>>);
+
     return finalResults.map((result) => ({ result }));
   }
 

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -6,7 +6,7 @@ import {
   type Statement,
   Transaction,
 } from 'blade-compiler';
-import { Hive } from 'hive';
+import { Hive, Selector } from 'hive';
 import { RemoteStorage } from 'hive/remote-storage';
 
 import { processStorableObjects, uploadStorableObjects } from '@/src/storage';
@@ -76,8 +76,12 @@ export const runQueries = async <T extends ResultRecord>(
         }),
     });
 
-    const database = await hive.get({ type: 'database', id: 'default' });
-    const results = await database.query(rawStatements);
+    const db = new Selector({ type: 'database', id: 'default' });
+    const results = await hive.storage.query(db, {
+      statements: rawStatements,
+      transaction: 'DEFERRED',
+    });
+
     const rawResults = results.map((result) => result.rows);
 
     const usableResults = transaction.formatResults(rawResults).map((result) => {

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -95,7 +95,6 @@ export const runQueries = async <T extends ResultRecord>(
     });
 
     const finalResults = formatResults<T>(usableResults as Array<Result<T>>);
-
     return finalResults.map((result) => ({ result }));
   }
 

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -1,3 +1,14 @@
+import {
+  type Query,
+  type RegularResult,
+  type Result,
+  type ResultRecord,
+  type Statement,
+  Transaction,
+} from 'blade-compiler';
+import { Hive } from 'hive';
+import { RemoteStorage } from 'hive/remote-storage';
+
 import { processStorableObjects, uploadStorableObjects } from '@/src/storage';
 import type {
   ExpandedFormattedResult,
@@ -10,13 +21,6 @@ import { WRITE_QUERY_TYPES } from '@/src/utils/constants';
 import { getResponseBody } from '@/src/utils/errors';
 import { formatDateFields, validateToken } from '@/src/utils/helpers';
 import { runQueriesWithTriggers } from '@/src/utils/triggers';
-import type {
-  Query,
-  RegularResult,
-  Result,
-  ResultRecord,
-  Statement,
-} from 'blade-compiler';
 
 interface RequestPayload {
   queries?: Array<Query>;
@@ -51,6 +55,49 @@ export const runQueries = async <T extends ResultRecord>(
   // initialized with triggers that run all the queries using a different data source,
   // we don't want to require a token.
   validateToken(options);
+
+  if (options.models) {
+    const rawQueries = queries
+      .filter((item) => 'query' in item)
+      .map((item) => item.query);
+
+    const transaction = new Transaction(rawQueries, { models: options.models });
+    const rawStatements = transaction.statements.map((item) => {
+      return { sql: item.statement, params: item.params as Array<string> };
+    });
+
+    const hive = new Hive({
+      storage: ({ logger, events }) =>
+        new RemoteStorage({
+          logger,
+          events,
+          remote: 'https://db.ronin.co',
+          token: options.token,
+        }),
+    });
+
+    const database = await hive.get({ type: 'database', id: 'default' });
+    const results = await database.query(rawStatements);
+    const rawResults = results.map((result) => result.rows);
+
+    const usableResults = transaction.formatResults(rawResults).map((result) => {
+      if ('record' in result) {
+        const { modelFields, ...rest } = result;
+        return { ...rest, schema: modelFields };
+      }
+
+      if ('records' in result) {
+        const { modelFields, ...rest } = result;
+        return { ...rest, schema: modelFields };
+      }
+
+      return result;
+    });
+
+    const finalResults = formatResults<T>(usableResults as Array<Result<T>>);
+
+    return finalResults.map((result) => ({ result }));
+  }
 
   let hasWriteQuery: boolean | null = null;
   let hasSingleQuery = true;

--- a/packages/blade-client/src/types/utils.ts
+++ b/packages/blade-client/src/types/utils.ts
@@ -48,6 +48,9 @@ export interface QueryHandlerOptions {
    * recommended to use the client provided in the `options.client` argument for triggers.
    */
   implicit?: boolean;
+
+  /** A list of models used for compiling Blade queries to SQL. */
+  models?: Array<Model>;
 }
 
 /**

--- a/packages/blade-client/tsconfig.json
+++ b/packages/blade-client/tsconfig.json
@@ -13,7 +13,7 @@
     "jsx": "react-jsx",
     "allowJs": true,
 
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,
     "noEmit": true,
     "pretty": true,

--- a/packages/blade/private/server/types/index.ts
+++ b/packages/blade/private/server/types/index.ts
@@ -25,6 +25,7 @@ import type {
   ResolvingSetTrigger as OriginalResolvingSetTrigger,
   SetTrigger as OriginalSetTrigger,
 } from 'blade-client/types';
+import type { Model } from 'blade-compiler';
 import type { ComponentType, FunctionComponent } from 'react';
 
 import type { ServerContext } from '@/private/server/context';
@@ -201,3 +202,4 @@ export type Triggers<TSchema = unknown> = Record<
 
 export type TriggersList<TSchema = unknown> = Record<string, Triggers<TSchema>>;
 export type PageList = Record<string, TreeItem | 'DIRECTORY'>;
+export type ModelList = { 'index.ts'?: Record<string, Model> };

--- a/packages/blade/private/server/types/server-list.d.ts
+++ b/packages/blade/private/server/types/server-list.d.ts
@@ -1,5 +1,6 @@
 declare module 'server-list' {
   export const pages: import('./index').PageList;
   export const triggers: import('./index').TriggersList;
+  export const schema: import('./index').ModelList;
   export const router: import('hono').Hono | null;
 }

--- a/packages/blade/private/server/utils/data.ts
+++ b/packages/blade/private/server/utils/data.ts
@@ -102,7 +102,7 @@ export const getRoninOptions = (
 
   return {
     triggers,
-    fetch: dataFetcher,
+    fetch: ENABLE_HIVE ? undefined : dataFetcher,
     requireTriggers,
     waitUntil,
     models: ENABLE_HIVE ? models : undefined,

--- a/packages/blade/private/server/utils/data.ts
+++ b/packages/blade/private/server/utils/data.ts
@@ -1,11 +1,14 @@
 import { waitUntil as vercelWaitUntil } from '@vercel/functions';
 import type { FormattedResults, QueryHandlerOptions } from 'blade-client/types';
 import { runQueries as runQueriesOnRonin } from 'blade-client/utils';
-import type { Query, ResultRecord } from 'blade-compiler';
+import type { Model, Query, ResultRecord } from 'blade-compiler';
 import type { Context, ExecutionContext } from 'hono';
+import { schema } from 'server-list';
 
 import type { TriggersList, WaitUntil } from '@/private/server/types';
 import { VERBOSE_LOGGING } from '@/private/server/utils/constants';
+
+const models: Array<Model> = Object.values(schema['index.ts'] || {});
 
 /**
  * A minimal mock implementation of the `ExecutionContext` interface.
@@ -48,6 +51,8 @@ export const getWaitUntil = (context?: Context): WaitUntil => {
 
   return dataFetcherWaitUntil;
 };
+
+const ENABLE_HIVE = import.meta.env.BLADE_DATA_WORKER === 'db.ronin.co';
 
 /**
  * Generate the options passed to the `ronin` JavaScript client.
@@ -100,6 +105,7 @@ export const getRoninOptions = (
     fetch: dataFetcher,
     requireTriggers,
     waitUntil,
+    models: ENABLE_HIVE ? models : undefined,
   };
 };
 

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -168,6 +168,7 @@ export const getFileListLoader = (
     ['pages', path.join(process.cwd(), 'pages')],
     ['triggers', path.join(process.cwd(), 'triggers')],
     ['components', path.join(process.cwd(), 'components')],
+    ['schema', path.join(process.cwd(), 'schema')],
   ];
 
   const filter = { id: /^(?:server-list|client-list)$/ };
@@ -205,7 +206,11 @@ export const getFileListLoader = (
       filter,
       async handler(id) {
         if (id === 'server-list') {
-          return getFileList(files, ['pages', 'triggers'], await exists(routerInputFile));
+          return getFileList(
+            files,
+            ['pages', 'triggers', 'schema'],
+            await exists(routerInputFile),
+          );
         }
 
         return getFileList(files, ['components']);

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -46,7 +46,9 @@ export const getClientReferenceLoader = (): RolldownPlugin => ({
     handler(code, id) {
       const extension = path.extname(id).slice(1) as 'ts' | 'tsx' | 'js' | 'jsx';
       const rawContents = code;
-      const relativeSourcePath = path.relative(process.cwd(), id).replace('virtual:/', '');
+      const relativeSourcePath = path
+        .relative(process.cwd(), id)
+        .replace('virtual:/', '');
       const chunkId = generateUniqueId();
 
       const contents = [

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -100,6 +100,9 @@ export const composeBuildContext = async (
       },
     },
 
+    // TODO: Remove this once the Hive client no longer depends on it.
+    external: ['events'],
+
     plugins: [
       getFileListLoader(options?.virtualFiles),
       getMdxLoader(environment),


### PR DESCRIPTION
This change enables Blade to compile Blade queries to SQL directly in its codebase, instead of having a production service take care of that, which will make debugging easier as well.