### PR TITLE
Prepare migration CLI for new engine

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -102,6 +102,7 @@
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.1",
         "@types/ini": "4.1.1",
+        "blade-client": "workspace:*",
         "blade-codegen": "workspace:*",
         "blade-compiler": "workspace:*",
         "blade-syntax": "workspace:*",
@@ -117,16 +118,12 @@
     "packages/blade-client": {
       "name": "blade-client",
       "version": "3.12.1",
-      "bin": {
-        "ronin": "./dist/bin/index.js",
-      },
       "dependencies": {
         "@ronin/engine": "0.1.23",
       },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
-        "blade-cli": "workspace:*",
         "blade-compiler": "workspace:*",
         "blade-syntax": "workspace:*",
         "hive": "1.0.8",

--- a/bun.lock
+++ b/bun.lock
@@ -111,9 +111,6 @@
         "tsup": "8.5.0",
         "typescript": "5.8.3",
       },
-      "peerDependencies": {
-        "@ronin/engine": ">=0.1.23",
-      },
     },
     "packages/blade-client": {
       "name": "blade-client",
@@ -1505,8 +1502,6 @@
 
     "blade-better-auth/typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
 
-    "blade-cli/@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
-
     "blade-cli/@types/bun": ["@types/bun@1.2.1", "", { "dependencies": { "bun-types": "1.2.1" } }, "sha512-iiCeMAKMkft8EPQJxSbpVRD0DKqrh91w40zunNajce3nMNNFd/LnAquVisSZC+UpTMjDwtcdyzbWct08IvEqRA=="],
 
     "blade-cli/ora": ["ora@8.1.1", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-YWielGi1XzG1UTvOaCFaNgEnuhZVMSHYkW/FQ7UX8O26PtlpdM84c0f7wLPlkvx2RfiQmnzd61d/MGxmpQeJPw=="],
@@ -1632,6 +1627,8 @@
     "blade-cli/ora/chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
 
     "blade-cli/ronin/@ronin/cli": ["@ronin/cli@0.3.19", "", { "dependencies": { "@dprint/formatter": "0.4.1", "@dprint/typescript": "0.93.3", "@iarna/toml": "2.2.5", "@inquirer/prompts": "7.2.3", "chalk-template": "1.1.0", "get-port": "7.1.0", "ini": "5.0.0", "json5": "2.2.3", "open": "10.1.0", "ora": "8.1.1", "resolve-from": "5.0.0" }, "peerDependencies": { "@ronin/codegen": ">=1.7.4", "@ronin/compiler": ">=0.18.8", "@ronin/engine": ">=0.1.23", "@ronin/syntax": ">=0.2.42" } }, "sha512-2M34NVDR/FRcjwhSFKMOVnI0uY0VFqrwotK7P+hQRwiOhE9juTsIPpNBSXPQwHRQBbHdoCxm1udibspDMphBXA=="],
+
+    "blade-cli/ronin/@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 
     "blade-cli/ronin/@ronin/syntax": ["@ronin/syntax@0.2.43", "", { "peerDependencies": { "@ronin/compiler": ">=0.18.8" } }, "sha512-1ieYLB3SqmD2JfavuKcf/0gTwgZD4X859FDJ+8R5oO3BS1EUfGpfk1kQ0sYUgp+fM4pu0+4gjbHlNDi6Z998ag=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -118,9 +118,6 @@
     "packages/blade-client": {
       "name": "blade-client",
       "version": "3.12.1",
-      "dependencies": {
-        "@ronin/engine": "0.1.23",
-      },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -1519,8 +1516,6 @@
     "blade-cli/tsup": ["tsup@8.5.0", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.25.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ=="],
 
     "blade-cli/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
-
-    "blade-client/@ronin/engine": ["@ronin/engine@0.1.23", "", { "dependencies": { "zod": "3.24.1" } }, "sha512-QDeikl4YEBFHEdful9+x5e8lLrxXvjhubJEYxnFfM7SJoFC9OxoE+Dq4g6mVzRuCI+gN+Odkdy3gd2ARr7eXFg=="],
 
     "blade-client/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
 

--- a/packages/blade-cli/package.json
+++ b/packages/blade-cli/package.json
@@ -89,8 +89,5 @@
     "ronin": "6.7.4",
     "tsup": "8.5.0",
     "typescript": "5.8.3"
-  },
-  "peerDependencies": {
-    "@ronin/engine": ">=0.1.23"
   }
 }

--- a/packages/blade-cli/package.json
+++ b/packages/blade-cli/package.json
@@ -82,9 +82,10 @@
     "@types/bun": "1.2.1",
     "@types/ini": "4.1.1",
     "bun-bagel": "1.1.0",
-    "blade-syntax": "workspace:*",
+    "blade-client": "workspace:*",
     "blade-codegen": "workspace:*",
     "blade-compiler": "workspace:*",
+    "blade-syntax": "workspace:*",
     "ronin": "6.7.4",
     "tsup": "8.5.0",
     "typescript": "5.8.3"

--- a/packages/blade-cli/src/commands/apply.ts
+++ b/packages/blade-cli/src/commands/apply.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { select } from '@inquirer/prompts';
+import { runQueries } from 'blade-client/utils';
 import { CompilerError } from 'blade-compiler';
 
 import type { MigrationFlags } from '@/src/utils/migration';
@@ -13,7 +14,6 @@ import {
 import { Protocol } from '@/src/utils/protocol';
 import { getOrSelectSpaceId } from '@/src/utils/space';
 import { spinner as ora } from '@/src/utils/spinner';
-import { runQueries } from 'blade-client/utils';
 
 /**
  * Applies a migration file to the database.

--- a/packages/blade-cli/src/commands/diff.ts
+++ b/packages/blade-cli/src/commands/diff.ts
@@ -18,6 +18,7 @@ export default async (
   sessionToken: string | undefined,
   flags: MigrationFlags,
   positionals: Array<string>,
+  enableHive: boolean,
 ): Promise<void> => {
   if (flags['force-create'] && flags.apply) {
     throw new Error('Cannot run `--apply` and `--force-create` at the same time');
@@ -123,7 +124,7 @@ export default async (
 
     // If desired, immediately apply the migration
     if (flags.apply) {
-      await apply(appToken, sessionToken, flags);
+      await apply(appToken, sessionToken, flags, enableHive);
     }
 
     process.exit(0);

--- a/packages/blade-cli/src/commands/diff.ts
+++ b/packages/blade-cli/src/commands/diff.ts
@@ -1,5 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { confirm } from '@inquirer/prompts';
+import { CompilerError, type Model } from 'blade-compiler';
+
 import apply from '@/src/commands/apply';
 import { Migration, type MigrationFlags } from '@/src/utils/migration';
 import { MIGRATIONS_PATH, getModelDefinitions, logTableDiff } from '@/src/utils/misc';
@@ -7,8 +10,6 @@ import { getModels } from '@/src/utils/model';
 import { Protocol } from '@/src/utils/protocol';
 import { getOrSelectSpaceId } from '@/src/utils/space';
 import { type Status, spinner } from '@/src/utils/spinner';
-import { confirm } from '@inquirer/prompts';
-import { CompilerError, type Model } from 'blade-compiler';
 
 /**
  * Creates a new migration based on model differences.
@@ -35,7 +36,9 @@ export default async (
     path.join(process.cwd(), positionals[positionals.indexOf('diff') + 1]);
 
   try {
-    const space = await getOrSelectSpaceId(sessionToken, spinner);
+    const space = enableHive
+      ? undefined
+      : await getOrSelectSpaceId(sessionToken, spinner);
     status = 'comparing';
     spinner.text = 'Comparing models';
 
@@ -45,6 +48,7 @@ export default async (
         : getModels({
             token: appToken ?? sessionToken,
             space,
+            enableHive,
           }),
       flags['force-drop'] ? [] : getModelDefinitions(modelsInCodePath),
     ]);

--- a/packages/blade-cli/src/index.ts
+++ b/packages/blade-cli/src/index.ts
@@ -95,7 +95,7 @@ export const run = async (config: { version: string }): Promise<void> => {
 
   // `diff` sub command
   if (normalizedPositionals.includes('diff')) {
-    return diff(appToken, session?.token, flags, positionals);
+    return diff(appToken, session?.token, flags, positionals, false);
   }
 
   // `apply` sub command
@@ -104,7 +104,7 @@ export const run = async (config: { version: string }): Promise<void> => {
       ? path.join(process.cwd(), positionals[positionals.indexOf('apply') + 1])
       : undefined;
 
-    return apply(appToken, session?.token, flags, migrationFilePath);
+    return apply(appToken, session?.token, flags, false, migrationFilePath);
   }
 
   // `types` sub command.

--- a/packages/blade-cli/src/utils/model.ts
+++ b/packages/blade-cli/src/utils/model.ts
@@ -9,7 +9,6 @@ import {
   getResponseBody,
 } from '@/src/utils/misc';
 import { spinner } from '@/src/utils/spinner';
-import type { Row } from '@ronin/engine/resources';
 
 /**
  * A model with fields in array format.
@@ -54,7 +53,7 @@ export const getModels = async (options?: {
 
   const transaction = new Transaction(queries);
 
-  let rawResults: Array<Array<Row>>;
+  let rawResults: Array<{ [x: string]: any }>;
 
   try {
     const nativeQueries = transaction.statements.map((statement) => ({

--- a/packages/blade-client/package.json
+++ b/packages/blade-client/package.json
@@ -60,9 +60,6 @@
   "engines": {
     "node": ">=18.17.0"
   },
-  "dependencies": {
-    "@ronin/engine": "0.1.23"
-  },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/bun": "1.2.4",

--- a/packages/blade-client/package.json
+++ b/packages/blade-client/package.json
@@ -6,9 +6,6 @@
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "bin": {
-    "ronin": "./dist/bin/index.js"
-  },
   "files": [
     "dist"
   ],
@@ -69,7 +66,6 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/bun": "1.2.4",
-    "blade-cli": "workspace:*",
     "blade-compiler": "workspace:*",
     "blade-syntax": "workspace:*",
     "hive": "1.0.8",

--- a/packages/blade-client/src/bin/index.ts
+++ b/packages/blade-client/src/bin/index.ts
@@ -1,6 +1,0 @@
-#!/usr/bin/env bun
-
-import { version } from '@/src/../package.json';
-import runCLI from 'blade-cli';
-
-runCLI({ version });

--- a/packages/blade/private/server/utils/data.ts
+++ b/packages/blade/private/server/utils/data.ts
@@ -52,7 +52,7 @@ export const getWaitUntil = (context?: Context): WaitUntil => {
   return dataFetcherWaitUntil;
 };
 
-const ENABLE_HIVE = import.meta.env.BLADE_DATA_WORKER === 'db.ronin.co';
+const enableHive = import.meta.env.BLADE_DATA_WORKER === 'db.ronin.co';
 
 /**
  * Generate the options passed to the `ronin` JavaScript client.
@@ -102,10 +102,10 @@ export const getRoninOptions = (
 
   return {
     triggers,
-    fetch: ENABLE_HIVE ? undefined : dataFetcher,
+    fetch: enableHive ? undefined : dataFetcher,
     requireTriggers,
     waitUntil,
-    models: ENABLE_HIVE ? models : undefined,
+    models: enableHive ? models : undefined,
   };
 };
 

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -57,6 +57,9 @@ const normalizedPositionals = positionals.map((positional) => positional.toLower
 // in CI, which must be independent of individual people.
 const appToken = process.env['RONIN_TOKEN'];
 
+// This determines whether the new database engine should be used.
+const enableHive = process.env['BLADE_DATA_WORKER'] === 'db.ronin.co';
+
 // If there is no active session, automatically start one and then continue with the
 // execution of the requested sub command, if there is one. If the `login` sub command
 // is invoked, we don't need to auto-login, since the command itself will handle it.
@@ -78,6 +81,7 @@ if (isDiffing)
       version: false,
     },
     positionals,
+    enableHive,
   );
 
 // `blade apply` command.
@@ -87,6 +91,7 @@ if (isApplying)
     debug: values.debug,
     help: false,
     version: false,
+    enableHive,
   });
 
 const isBuilding = normalizedPositionals.includes('build');


### PR DESCRIPTION
This change adds a new experimental flag (currently only meant to be used by the RONIN team) for enabling the new database engine (introduced in https://github.com/ronin-co/blade/pull/413) within the `blade diff` and `blade apply` commands.