### PR TITLE
Decrease size of client-side bundles

### DIFF
--- a/packages/blade-cli/src/commands/apply.ts
+++ b/packages/blade-cli/src/commands/apply.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { select } from '@inquirer/prompts';
-import { runQueries } from 'blade-client/utils';
+import { runQueries } from 'blade-client';
 import { CompilerError } from 'blade-compiler';
 
 import type { MigrationFlags } from '@/src/utils/migration';

--- a/packages/blade-cli/src/utils/model.ts
+++ b/packages/blade-cli/src/utils/model.ts
@@ -1,4 +1,4 @@
-import { runQueries } from 'blade-client/utils';
+import { runQueries } from 'blade-client';
 import { type Model, type ModelField, type Query, Transaction } from 'blade-compiler';
 
 import logIn from '@/src/commands/login';

--- a/packages/blade-client/src/index.ts
+++ b/packages/blade-client/src/index.ts
@@ -1,3 +1,4 @@
+import { runQueriesWithStorageAndTriggers } from '@/src/queries';
 import { isStorableObject } from '@/src/storage';
 import type { PromiseTuple, QueryHandlerOptions } from '@/src/types/utils';
 import { queriesHandler, queryHandler } from '@/src/utils/handlers';
@@ -208,5 +209,7 @@ export const batch = factory.batch as <
 
 export const sql = factory.sql;
 export const sqlBatch = factory.sqlBatch;
+
+export const runQueries = runQueriesWithStorageAndTriggers;
 
 export default createSyntaxFactory;

--- a/packages/blade-client/src/utils/index.ts
+++ b/packages/blade-client/src/utils/index.ts
@@ -1,3 +1,2 @@
-export { runQueriesWithStorageAndTriggers as runQueries } from '@/src/queries';
 export { processStorableObjects, isStorableObject } from '@/src/storage';
 export { ClientError } from '@/src/utils/errors';

--- a/packages/blade/private/server/utils/data.ts
+++ b/packages/blade/private/server/utils/data.ts
@@ -1,6 +1,6 @@
 import { waitUntil as vercelWaitUntil } from '@vercel/functions';
+import { runQueries as runQueriesOnRonin } from 'blade-client';
 import type { FormattedResults, QueryHandlerOptions } from 'blade-client/types';
-import { runQueries as runQueriesOnRonin } from 'blade-client/utils';
 import type { Model, Query, ResultRecord } from 'blade-compiler';
 import type { Context, ExecutionContext } from 'hono';
 import { schema } from 'server-list';


### PR DESCRIPTION
This change removes unnecessary code from our client-side bundles by moving exports into different files, which allows for correctly tree-shaking the imported code.