### PR TITLE
Enable `nodejs_compat` flag in default Wrangler config

### DIFF
--- a/packages/blade/private/shell/utils/providers.ts
+++ b/packages/blade/private/shell/utils/providers.ts
@@ -165,7 +165,7 @@ export const transformToCloudflareOutput = async (): Promise<void> => {
             name: currentDirectoryName,
             main: '.blade/edge-worker.js',
             compatibility_date: '2025-06-02',
-            compatibility_flags: [],
+            compatibility_flags: ['nodejs_compat'],
             assets: {
               binding: 'ASSETS',
               directory: '.blade/',


### PR DESCRIPTION
This change updates the default `wrangler.jsonc` config file generated when deploying to Cloudflare Workers to enable the `nodejs_compat` compatibility flag.