### PR TITLE
Ensure templates use the latest version of `blade`

### DIFF
--- a/packages/create-blade/templates/advanced/bun.lock
+++ b/packages/create-blade/templates/advanced/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "advanced-example",
       "dependencies": {
-        "blade": "3.10.10",
+        "blade": "3.13.3",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
       },
@@ -169,7 +169,7 @@
 
     "ansis": ["ansis@4.1.0", "", {}, "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w=="],
 
-    "blade": ["blade@3.10.10", "", { "dependencies": { "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "dotenv": "16.5.0", "gradient-string": "3.0.0", "rolldown": "1.0.0-beta.32", "ronin": "6.8.0" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-t5NRSptBG3z5ytIowU3tUbDMESmsvlr6kl1g06TGoV4YCm17kM6OA1w3ZYXUMU3pQaASPCe3f8SqdM3OzreBjQ=="],
+    "blade": ["blade@3.13.3", "", { "dependencies": { "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "dotenv": "16.5.0", "gradient-string": "3.0.0", "rolldown": "1.0.0-beta.32", "ronin": "6.8.0" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-tjlKhvLMPoT9J8mS4a07Xz6vD8k+Ued0Hor/BMLEuiWFyNYPpLgbfKLUCq8EFfkYCLTQTiTtnYeFBGefRWJvwA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/packages/create-blade/templates/advanced/package.json
+++ b/packages/create-blade/templates/advanced/package.json
@@ -10,7 +10,7 @@
   },
   "author": "ronin",
   "dependencies": {
-    "blade": "3.10.10",
+    "blade": "3.13.3",
     "react": "0.0.0-experimental-df12d7eac-20230510",
     "react-dom": "0.0.0-experimental-df12d7eac-20230510"
   },

--- a/packages/create-blade/templates/basic/bun.lock
+++ b/packages/create-blade/templates/basic/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "basic-example",
       "dependencies": {
-        "blade": "3.10.10",
+        "blade": "3.13.3",
         "react": "0.0.0-experimental-df12d7eac-20230510",
         "react-dom": "0.0.0-experimental-df12d7eac-20230510",
       },
@@ -169,7 +169,7 @@
 
     "ansis": ["ansis@4.1.0", "", {}, "sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w=="],
 
-    "blade": ["blade@3.10.10", "", { "dependencies": { "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "dotenv": "16.5.0", "gradient-string": "3.0.0", "rolldown": "1.0.0-beta.32", "ronin": "6.8.0" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-t5NRSptBG3z5ytIowU3tUbDMESmsvlr6kl1g06TGoV4YCm17kM6OA1w3ZYXUMU3pQaASPCe3f8SqdM3OzreBjQ=="],
+    "blade": ["blade@3.13.3", "", { "dependencies": { "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.6", "@tailwindcss/oxide": "4.1.6", "dotenv": "16.5.0", "gradient-string": "3.0.0", "rolldown": "1.0.0-beta.32", "ronin": "6.8.0" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-tjlKhvLMPoT9J8mS4a07Xz6vD8k+Ued0Hor/BMLEuiWFyNYPpLgbfKLUCq8EFfkYCLTQTiTtnYeFBGefRWJvwA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 

--- a/packages/create-blade/templates/basic/package.json
+++ b/packages/create-blade/templates/basic/package.json
@@ -10,7 +10,7 @@
   },
   "author": "ronin",
   "dependencies": {
-    "blade": "3.10.10",
+    "blade": "3.13.3",
     "react": "0.0.0-experimental-df12d7eac-20230510",
     "react-dom": "0.0.0-experimental-df12d7eac-20230510"
   },


### PR DESCRIPTION
This change upgrades all `bun create blade` project templates to use the latest available version of `blade`, which at the time of writing is version `3.13.3`.