### PR TITLE
Replaced `ronin` CLI documentation with `blade` CLI

### DIFF
--- a/docs/pages/api-routes.mdx
+++ b/docs/pages/api-routes.mdx
@@ -63,4 +63,4 @@ app.post('/some-path', async (c) => {
 });
 ```
 
-However, note that paths mounted in this Hono app cannot interface with the rest of your Blade app (like your pages) in any way. They are only meant to be used in edge cases where you cannot rely on Blade's [trigger](https://ronin.co/docs/models/triggers) feature. In other words, your Hono app and your Blade app are two different apps running on the same domain.
+However, note that paths mounted in this Hono app cannot interface with the rest of your Blade app (like your pages) in any way. They are only meant to be used in edge cases where you cannot rely on Blade's [trigger](/models/triggers) feature. In other words, your Hono app and your Blade app are two different apps running on the same domain.

--- a/docs/pages/client.mdx
+++ b/docs/pages/client.mdx
@@ -78,7 +78,7 @@ const ronin = roninFactory({
 });
 ```
 
-Note that, for the `add`, `set`, and `remove` [query types](/docs/queries/types), the RONIN client specifies `cache: 'no-store'` by default, which skips the cache in Next.js, for example.
+Note that, for the `add`, `set`, and `remove` [query types](/queries/crud), the RONIN client specifies `cache: 'no-store'` by default, which skips the cache in Next.js, for example.
 
 ## Config Factory
 

--- a/docs/pages/hooks.mdx
+++ b/docs/pages/hooks.mdx
@@ -353,9 +353,9 @@ Usually, in React, the [use](https://react.dev/reference/react/use) hook is used
 
 In Blade, however, since Blade purposefully does not support Suspense and also does not support asynchronous components, the hook is used to load data instead.
 
-Specifically, the hook reflects the full capabilities of the [RONIN query syntax](https://ronin.co/docs/queries) (which is as powerful as SQL) and thereby allows for easily querying records on your database.
+Specifically, the hook reflects the full capabilities of the [RONIN query syntax](/docs/queries) (which is as powerful as SQL) and thereby allows for easily querying records on your database.
 
-By default, if you provide a `RONIN_TOKEN` environment variable that contains a RONIN app token, these queries will simply target your RONIN database. However, if the environment variable is not provided, any other data source can be defined using [triggers](https://ronin.co/docs/models/triggers) instead.
+By default, if you provide a `RONIN_TOKEN` environment variable that contains a RONIN app token, these queries will simply target your RONIN database. However, if the environment variable is not provided, any other data source can be defined using [triggers](/models/triggers) instead.
 
 ```tsx
 import { use } from 'blade/server/hooks';
@@ -368,7 +368,7 @@ const Page = () => {
 };
 ```
 
-The queries you provide can be as complex as you would like them to be (see the [query syntax docs](https://ronin.co/docs/queries) for more details on what you can do):
+The queries you provide can be as complex as you would like them to be (see the [query syntax docs](/queries) for more details on what you can do):
 
 ```tsx
 import { use } from 'blade/server/hooks';

--- a/docs/pages/hooks.mdx
+++ b/docs/pages/hooks.mdx
@@ -136,7 +136,7 @@ The max age of cookies currently defaults to 365 days, which is not yet customiz
 
 Allows for performing data mutations and updates all `use` queries accordingly.
 
-The function exposes all [write query types](https://ronin.co/docs/queries/types) available on RONIN, but any other data source may be used as well.
+The function exposes all [write query types](/queries/crud) available on RONIN, but any other data source may be used as well.
 
 ```tsx
 import { useMutation } from 'blade/client/hooks';

--- a/docs/pages/models/index.mdx
+++ b/docs/pages/models/index.mdx
@@ -31,7 +31,7 @@ npm install -g ronin
 Afterward, log into your RONIN account:
 
 ```bash title="Terminal"
-ronin login
+blade login
 ```
 
 Next, create the file (in your project's root directory) that will contain the model definitions for your project:
@@ -64,7 +64,7 @@ In the example above, we defined a model named `Account` with three fields: `nam
 Once you've defined your models locally, you can compare them to the current state of your database like this:
 
 ```bash title="Terminal"
-ronin diff
+blade diff
 ```
 
 Running the command above will produce a so-called "migration protocol" in the `schema` directory. This protocol contains all the steps required to update your database to match your local schema definition.
@@ -72,7 +72,7 @@ Running the command above will produce a so-called "migration protocol" in the `
 To apply the changes to your database, run the following command:
 
 ```bash title="Terminal"
-ronin apply
+blade apply
 ```
 
 Afterward, you can start sending queries to your database that make use of the newly added (or updated) models in your database schema.
@@ -80,7 +80,7 @@ Afterward, you can start sending queries to your database that make use of the n
 In the future, if you'd like to immediately apply your local changes to your database without first reviewing them, run thhis command:
 
 ```bash title="Terminal"
-ronin diff --apply
+blade diff --apply
 ```
 
 Like this, the generated migration protocol will be applied immediately.

--- a/docs/pages/models/triggers.mdx
+++ b/docs/pages/models/triggers.mdx
@@ -54,7 +54,7 @@ await add.account.with.name('Engineering');
 ## When to use Triggers
 
 In general, you should refrain from using triggers for anything that can be accomplished
-using [model definitions](/docs/models), to ensure the best performance and
+using [model definitions](/models), to ensure the best performance and
 maintainability of your queries.
 
 For example, if you need to provide any form of static defaults for your queries (meaning
@@ -125,7 +125,7 @@ beforeAdd: (query, multiple, options) => {
 
 These triggers are executed instead of the original query, within the same transaction.
 They can be used to validate the original query, or transform it by modifying its
-[query instructions](/docs/queries/instructions).
+[query instructions](/queries/instructions).
 
 They must return exactly one query.
 
@@ -228,7 +228,7 @@ types that read data, such as `get` or `count`.
 
 The following arguments are available for all triggers:
 
-- `query`: An object containing the [instructions](/docs/queries/instructions)
+- `query`: An object containing the [instructions](/queries/instructions)
   of the query that is being executed. The argument neither contains the
   [type](/docs/queries/types) of the query, nor the
   [target](/docs/queries/targets) of the query. It only contains the

--- a/docs/pages/models/triggers.mdx
+++ b/docs/pages/models/triggers.mdx
@@ -217,7 +217,7 @@ it allows for diffing the field values of a record.
 #### Methods
 
 Unlike the other types of triggers, triggers of type `following` can only be defined for
-[query types](/docs/queries/types) that write data. They cannot be defined for query
+[query types](/queries/crud) that write data. They cannot be defined for query
 types that read data, such as `get` or `count`.
 
 - `followingAdd`: Executed after an `add` query.
@@ -230,7 +230,7 @@ The following arguments are available for all triggers:
 
 - `query`: An object containing the [instructions](/queries/instructions)
   of the query that is being executed. The argument neither contains the
-  [type](/docs/queries/types) of the query, nor the
+  [type](/queries/crud) of the query, nor the
   [target](/docs/queries/targets) of the query. It only contains the
   instructions of the query. The type and target are already evident from the
   name of the trigger and the model for which it was defined.

--- a/docs/pages/queries/crud.mdx
+++ b/docs/pages/queries/crud.mdx
@@ -43,9 +43,9 @@ for (const postDetails of posts) {
 
 The following query instructions may be used in combination with queries of type `add`:
 
-- [Asserting Fields](/docs/queries/instructions) (`with`)
+- [Asserting Fields](/queries/instructions) (`with`)
 
-- [Resolving Related Records](/docs/queries/instructions) (`using`)
+- [Resolving Related Records](/queries/instructions) (`using`)
 
 ### Default Fields
 

--- a/docs/pages/queries/index.mdx
+++ b/docs/pages/queries/index.mdx
@@ -120,7 +120,7 @@ Any level that contains a period (`.`) can instead be a nested object if you dec
 
 Additional flexibility is provided as every **key** inside the object can contain dot notation as well.
 
-This is especially useful when addressing nested fields (either of a [relational record](/docs/queries/instructions) or the [RONIN metadata](/docs/platform/default-fields)) or when writing extremely sophisticated queries, as the syntax continues to remain readable and even easy to augment with comments.
+This is especially useful when addressing nested fields (either of a [relational record](/queries/instructions) or the [RONIN metadata](/docs/platform/default-fields)) or when writing extremely sophisticated queries, as the syntax continues to remain readable and even easy to augment with comments.
 
 For example, the query below retrieves all records of the model “Blog Post” where the author is matched using a given username/handle, and the record is older than a given date:
 

--- a/docs/pages/queries/index.mdx
+++ b/docs/pages/queries/index.mdx
@@ -186,7 +186,7 @@ In the following example, we want to retrieve a record of the “Blog Post” mo
 use.blogPost.with.author(['acc_vais0g9rrk995tz0', 'acc_fa0k5kkw35fik9pu']);
 ```
 
-The array syntax can currently be applied to **any level** inside the `with` [query instruction](/docs/queries/instructions):
+The array syntax can currently be applied to **any level** inside the `with` [query instruction](/queries/instructions):
 
 ```ts
 use.accounts.with.handle(['leo', 'juri']);

--- a/docs/pages/queries/instructions.mdx
+++ b/docs/pages/queries/instructions.mdx
@@ -273,7 +273,7 @@ Please note that resolving more fields affects the performance of your query, so
 
 In order to ensure the maximum security of your data, you might want to prevent specific fields from ever leaving RONIN’s storage. You can achieve this by using the `selecting` instruction.
 
-By default, every record will always contain all of its stored fields when retrieved via the `get` [query type](/docs/queries/query-types). To exclude a particular field, it has to be added to `selecting` explicitly.
+By default, every record will always contain all of its stored fields when retrieved via the `get` [query type](/queries/crud). To exclude a particular field, it has to be added to `selecting` explicitly.
 
 ```ts
 use.account({


### PR DESCRIPTION
This change makes a number of small tweaks to the Blade documentation to both:
 - Replace all instances of using the `ronin` CLI in favour of the `blade` CLI since they are now interoperable
 - Fixed a number of broken links