### PR TITLE
Fix `--apply` flag for `blade diff` command

### DIFF
--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -77,9 +77,9 @@ if (isDiffing)
     appToken,
     session?.token,
     {
-      debug: values.debug,
       help: false,
       version: false,
+      ...values,
     },
     positionals,
     enableHive,
@@ -92,9 +92,9 @@ if (isApplying)
     appToken,
     session?.token,
     {
-      debug: values.debug,
       help: false,
       version: false,
+      ...values,
     },
     enableHive,
   );
@@ -106,9 +106,9 @@ if (isGeneratingTypes) {
     appToken,
     session?.token,
     {
-      debug: values.debug,
       help: false,
       version: false,
+      ...values,
     },
     enableHive,
   );


### PR DESCRIPTION
This change updates how all `blade-cli` sub commands are used within the `blade` CLI by making sure that all additional flags are passed down to their respective handler. Before this only the required flags were being handed down granularly.