### PR TITLE
Correctly dedupe queries

### DIFF
--- a/docs/pages/layout.tsx
+++ b/docs/pages/layout.tsx
@@ -46,7 +46,7 @@ const NAV: Array<NavGroup> = [
         id: 'deploying',
         name: 'Deploying',
         href: '/deploying',
-      }
+      },
     ],
   },
   {

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -278,7 +278,7 @@ const collectPromises = (
 
           // If the query was already collected, don't add it again.
           if (
-            serverContext.collected.queries.some((item) => {
+            freshlyAdded.queries.some((item) => {
               return item.query === query && item.database === database;
             })
           ) {
@@ -296,7 +296,7 @@ const collectPromises = (
         const { token, secret, algo } = details.__blade_jwt;
 
         // If the query was already collected, don't add it again.
-        if (serverContext.collected.jwts[token]) continue;
+        if (freshlyAdded.jwts[token]) continue;
 
         // If the JWT was not collected yet, add it to the collection.
         freshlyAdded.jwts[token] = {


### PR DESCRIPTION
This change ensures that, if the same query is used across multiple leaves of a rendering tree (layouts and pages), it will be deduped and only executed once.