### PR TITLE
Refactor trigger invocation logic

### DIFF
--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -39,10 +39,10 @@ interface StatementPerDatabase {
   database?: string;
 }
 
-export type ResultsPerDatabase<T> = Array<{
+export interface ResultPerDatabase<T> {
   result: FormattedResults<T>[number];
   database?: string;
-}>;
+}
 
 const clients: Record<string, Hive> = {};
 
@@ -58,7 +58,7 @@ const clients: Record<string, Hive> = {};
 export const runQueries = async <T extends ResultRecord>(
   queries: Array<QueryPerDatabase> | Array<StatementPerDatabase>,
   options: QueryHandlerOptions = {},
-): Promise<ResultsPerDatabase<T>> => {
+): Promise<Array<ResultPerDatabase<T>>> => {
   // Ensure that a token is present. We must only perform this check if there is a
   // guarantee that actual queries must be executed. For example, if the client is
   // initialized with triggers that run all the queries using a different data source,
@@ -189,7 +189,7 @@ export const runQueries = async <T extends ResultRecord>(
   const responseResults = await getResponseBody<QueryResponse<T>>(response);
 
   const startFormatting = performance.now();
-  const formattedResults: ResultsPerDatabase<T> = [];
+  const formattedResults: Array<ResultPerDatabase<T>> = [];
 
   if ('results' in responseResults) {
     const usableResults = responseResults.results as Array<Result<T>>;

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -29,8 +29,15 @@ interface RequestPayload {
 
 type RequestBody = RequestPayload | Record<string, RequestPayload>;
 
-export type QueriesPerDatabase = Array<{ query: Query; database?: string }>;
-type StatementsPerDatabase = Array<{ statement: Statement; database?: string }>;
+export interface QueryPerDatabase {
+  query: Query;
+  database?: string;
+}
+
+interface StatementPerDatabase {
+  statement: Statement;
+  database?: string;
+}
 
 export type ResultsPerDatabase<T> = Array<{
   result: FormattedResults<T>[number];
@@ -49,7 +56,7 @@ const clients: Record<string, Hive> = {};
  * @returns Promise resolving the queried data.
  */
 export const runQueries = async <T extends ResultRecord>(
-  queries: QueriesPerDatabase | StatementsPerDatabase,
+  queries: Array<QueryPerDatabase> | Array<StatementPerDatabase>,
   options: QueryHandlerOptions = {},
 ): Promise<ResultsPerDatabase<T>> => {
   // Ensure that a token is present. We must only perform this check if there is a

--- a/packages/blade-client/src/utils/triggers.ts
+++ b/packages/blade-client/src/utils/triggers.ts
@@ -456,16 +456,17 @@ interface QueryWithResult<T> extends QueryFromTrigger {
 }
 
 /**
- * Executes queries and also invokes any potential triggers (such as `followingAdd`)
- * that might have been provided as part of `options.triggers`.
+ * Executes any synchronous triggers that might have been provided for a list of queries,
+ * meaning the kind of triggers that can return queries.
  *
- * @param queries - A list of queries to execute.
- * @param options - A list of options to change how the queries are executed. To
- * run triggers, the `options.triggers` property must contain a map of triggers.
+ * @param queries - A list of queries to execute triggers for.
+ * @param client - An instance of the client that allows triggers to run queries inline.
+ * @param context - A map used for sharing values between the triggers of a model.
+ * @param options - A list of options to change how the triggers are executed.
  *
- * @returns The results of the queries that were passed.
+ * @returns The list of queries after they were transformed by triggers.
  */
-export const primeQueriesWithTriggers = async (
+export const applySynchronousTriggers = async (
   queries: Array<QueryPerDatabase>,
   client: ReturnType<typeof createSyntaxFactory>,
   context: Map<string, any>,
@@ -667,7 +668,7 @@ export const runQueriesWithTriggers = async <T extends ResultRecord>(
   const context = new Map<string, any>();
 
   const queryList: Array<QueryWithResult<T>> = (
-    await primeQueriesWithTriggers(queries, client, context, options)
+    await applySynchronousTriggers(queries, client, context, options)
   ).map((item) => ({
     ...item,
     result: EMPTY,

--- a/packages/blade-client/src/utils/triggers.ts
+++ b/packages/blade-client/src/utils/triggers.ts
@@ -466,7 +466,7 @@ interface QueryWithResult<T> extends QueryFromTrigger {
  *
  * @returns The list of queries after they were transformed by triggers.
  */
-export const applySynchronousTriggers = async (
+export const applySyncTriggers = async (
   queries: Array<QueryPerDatabase>,
   client: ReturnType<typeof createSyntaxFactory>,
   context: Map<string, any>,
@@ -627,7 +627,7 @@ export const applySynchronousTriggers = async (
  *
  * @returns The results provided by the triggers.
  */
-export const applyAsynchronousTriggers = async <T extends ResultRecord>(
+export const applyAsyncTriggers = async <T extends ResultRecord>(
   queries: Array<QueryFromTrigger>,
   client: ReturnType<typeof createSyntaxFactory>,
   context: Map<string, any>,
@@ -796,13 +796,8 @@ export const runQueriesWithTriggers = async <T extends ResultRecord>(
   // Lets people share arbitrary values between the triggers of a model.
   const context = new Map<string, any>();
 
-  const queryList = await applySynchronousTriggers(queries, client, context, options);
-  const queryResults = await applyAsynchronousTriggers(
-    queryList,
-    client,
-    context,
-    options,
-  );
+  const queryList = await applySyncTriggers(queries, client, context, options);
+  const queryResults = await applyAsyncTriggers<T>(queryList, client, context, options);
 
   return queryResults;
 };

--- a/packages/blade-client/src/utils/triggers.ts
+++ b/packages/blade-client/src/utils/triggers.ts
@@ -664,16 +664,14 @@ export const runQueriesWithTriggers = async <T extends ResultRecord>(
   // Lets people share arbitrary values between the triggers of a model.
   const context = new Map<string, any>();
 
-  const queryList = (await primeQueriesWithTriggers(
-    queries,
-    client,
-    context,
-    options,
-  )) as Array<
+  const queryList: Array<
     QueriesFromTriggers[number] & {
       result: FormattedResults<T>[number] | symbol;
     }
-  >;
+  > = (await primeQueriesWithTriggers(queries, client, context, options)).map((item) => ({
+    ...item,
+    result: EMPTY,
+  }));
 
   // Invoke `resolvingGet`, `resolvingSet`, `resolvingAdd`, `resolvingRemove`,
   // and `resolvingCount`.

--- a/packages/blade-client/src/utils/triggers.ts
+++ b/packages/blade-client/src/utils/triggers.ts
@@ -1,9 +1,5 @@
 import { createSyntaxFactory } from '@/src/index';
-import {
-  type QueryPerDatabase,
-  type ResultsPerDatabase,
-  runQueries,
-} from '@/src/queries';
+import { type QueryPerDatabase, type ResultPerDatabase, runQueries } from '@/src/queries';
 import type {
   FormattedResults,
   QueryHandlerOptions,
@@ -632,7 +628,7 @@ export const applyAsyncTriggers = async <T extends ResultRecord>(
   client: ReturnType<typeof createSyntaxFactory>,
   context: Map<string, any>,
   options: QueryHandlerOptions = {},
-): Promise<ResultsPerDatabase<T>> => {
+): Promise<Array<ResultPerDatabase<T>>> => {
   const { triggers, waitUntil, implicit: implicitRoot } = options;
 
   const queryList: Array<QueryWithResult<T>> = queries.map((item) => ({
@@ -758,7 +754,7 @@ export const applyAsyncTriggers = async <T extends ResultRecord>(
 export const runQueriesWithTriggers = async <T extends ResultRecord>(
   queries: Array<QueryPerDatabase>,
   options: QueryHandlerOptions = {},
-): Promise<ResultsPerDatabase<T>> => {
+): Promise<Array<ResultPerDatabase<T>>> => {
   const { triggers, waitUntil, requireTriggers } = options;
 
   const triggerErrorType = requireTriggers !== 'all' ? ` ${requireTriggers}` : '';

--- a/packages/blade-client/src/utils/triggers.ts
+++ b/packages/blade-client/src/utils/triggers.ts
@@ -488,7 +488,7 @@ export const applySyncTriggers = async (
   await Promise.all(
     queryList.map(async ({ query, database, implicit }, index) => {
       const triggerResults = await invokeTriggers(
-        triggers!,
+        triggers,
         'before',
         { query },
         {
@@ -514,7 +514,7 @@ export const applySyncTriggers = async (
   await Promise.all(
     queryList.map(async ({ query, database, implicit }, index) => {
       const triggerResults = await invokeTriggers(
-        triggers!,
+        triggers,
         'during',
         { query },
         {
@@ -551,7 +551,7 @@ export const applySyncTriggers = async (
   await Promise.all(
     queryList.map(async ({ query, database, implicit }, index) => {
       const triggerResults = await invokeTriggers(
-        triggers!,
+        triggers,
         'after',
         { query },
         {
@@ -645,7 +645,7 @@ export const applyAsyncTriggers = async <T extends ResultRecord>(
   await Promise.all(
     queryList.map(async ({ query, database, implicit }, index) => {
       const triggerResults = await invokeTriggers(
-        triggers!,
+        triggers,
         'resolving',
         { query },
         {
@@ -703,7 +703,7 @@ export const applyAsyncTriggers = async <T extends ResultRecord>(
 
     // Run the actual trigger functions.
     const promise = invokeTriggers(
-      triggers!,
+      triggers,
       'following',
       { query, resultBefore, resultAfter },
       {

--- a/packages/blade-client/src/utils/triggers.ts
+++ b/packages/blade-client/src/utils/triggers.ts
@@ -477,7 +477,7 @@ export const primeQueriesWithTriggers = async (
     code: 'TRIGGER_REQUIRED',
   });
 
-  const queryList: QueriesFromTriggers = queries;
+  const queryList: QueriesFromTriggers = [...queries];
 
   // Invoke `beforeAdd`, `beforeGet`, `beforeSet`, `beforeRemove`, and `beforeCount`.
   await Promise.all(


### PR DESCRIPTION
Instead of invoking all available types of triggers in a single function, this change splits the invocation logic for different types of triggers into two different functions:

- One function for [synchronous triggers](https://blade.im/models/triggers#synchronous-triggers)
- One function for [asynchronous triggers](https://blade.im/models/triggers#asynchronous-triggers)

This will make subsequent changes easier.

The tests are unchanged and are passing as-is, so the behavior didn't change — only the structure of the code.