### PR TITLE
Allow for flushing UI after redirect

### DIFF
--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -525,6 +525,8 @@ const renderReactTree = async (
   initial: boolean,
   /** A list of options for customizing the rendering behavior. */
   options: Omit<PageFetchingOptions, 'queries'> & {
+    /** A function for keeping the process alive until a promise has been resolved. */
+    waitUntil: ServerContext['waitUntil'];
     /** Whether an error page should be rendered, and for which error code. */
     error?: 404 | 500;
     /** The reason why the error page is being rendered. */
@@ -534,9 +536,7 @@ const renderReactTree = async (
      * page is not renderable.
      */
     forceNativeError?: boolean;
-    /** A function for keeping the process alive until a promise has been resolved. */
-    waitUntil: ServerContext['waitUntil'];
-    /** Whether triggers should be allowed to flush UI updates for the current request. */
+    /** Allows for flushing asynchronous UI updates after the first response. */
     stream?: SSEStreamingApi;
   },
   /** Existing properties that the server context should be primed with. */

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -542,6 +542,7 @@ const renderReactTree = async (
   /** Existing properties that the server context should be primed with. */
   existingCollected?: Collected,
 ): Promise<Response> => {
+  // Do not modify the original request URL.
   const url = new URL(requestURL);
 
   // See https://github.com/ronin-co/blade/pull/31 for more details.
@@ -582,7 +583,7 @@ const renderReactTree = async (
         : undefined,
     };
 
-    return flushSession(options.stream, url, headers, true, newOptions);
+    return flushSession(options.stream, requestURL, requestHeaders, true, newOptions);
   };
 
   const serverContext: ServerContext = {


### PR DESCRIPTION
This change ensures that the UI updates can still be streamed from the server, even after a redirect happened.

Specifically, we offer support for rendering a different page right after a query has been executed:

```typescript
await add.account.with.handle('test', {
  redirect: `/accounts/{0.id}`,
});
```

Previously, this would break the UI flushing, but with the current change, flushing the UI still works.