### PR TITLE
Ensure up-to-date session URL

### DIFF
--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -506,6 +506,10 @@ export const flushSession = async (
 
     // If the URL of the page changed while it was rendered (for example because of a
     // redirect), we have to update the session URL accordingly.
+    //
+    // In the case that an initial redirect (`Location` header) was performed, we don't
+    // need to update the session URL, because the client will terminate the stream in
+    // that case anyways (that's just default browser behavior).
     const newURL = response.headers.get('Content-Location');
     if (newURL) sessionURL = new URL(newURL, sessionURL);
 


### PR DESCRIPTION
If the server-side performs a redirect, subsequent UI flushes (be it revalidation or manually triggered ones) have to consider the new URL instead of the one for which the stream session was originally created.