### PR TITLE
Add support for external dependencies

### DIFF
--- a/packages/blade/private/shell/constants.ts
+++ b/packages/blade/private/shell/constants.ts
@@ -9,6 +9,9 @@ export const sourceDirPath = join(dirname(currentFilePath), '..');
 export const publicDirectory = resolve(process.cwd(), 'public');
 export const outputDirectory = resolve(process.cwd(), '.blade');
 
+export const tsconfigFilename = resolve(process.cwd(), 'tsconfig.json');
+export const packageMetaFilename = resolve(process.cwd(), 'package.json');
+
 // The path at which people can define a custom Hono app that Blade will mount.
 export const routerInputFile = join(process.cwd(), 'router.ts');
 

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -100,9 +100,6 @@ export const composeBuildContext = async (
       },
     },
 
-    // TODO: Remove this once the Hive client no longer depends on it.
-    external: ['events'],
-
     plugins: [
       getFileListLoader(options?.virtualFiles),
       getMdxLoader(environment),

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
   type OutputOptions,
@@ -10,7 +11,9 @@ import {
   clientInputFile,
   nodePath,
   outputDirectory,
+  packageMetaFilename,
   serverInputFolder,
+  tsconfigFilename,
 } from '@/private/shell/constants';
 import {
   getClientReferenceLoader,
@@ -69,8 +72,23 @@ export const composeBuildContext = async (
   const serverEntry = path.join(serverInputFolder, `${provider}.js`);
   const swEntry = path.join(serverInputFolder, 'service-worker.js');
 
-  const tsconfigFilename = path.join(process.cwd(), 'tsconfig.json');
-  const tsconfigExists = options?.virtualFiles ? false : await exists(tsconfigFilename);
+  let tsconfigExists: boolean;
+  let packageMetaFile: string | undefined;
+
+  if (options?.virtualFiles) {
+    const filePath = `/${path.basename(packageMetaFilename)}`;
+
+    packageMetaFile = options?.virtualFiles?.find((item) => {
+      return item.path === filePath;
+    })?.content;
+  } else {
+    [tsconfigExists, packageMetaFile] = await Promise.all([
+      exists(tsconfigFilename),
+      readFile(packageMetaFilename, 'utf-8'),
+    ]);
+  }
+
+  const packageMetaContent = packageMetaFile ? JSON.parse(packageMetaFile) : {};
 
   const input: Record<string, string> = {
     client: clientInputFile,
@@ -99,6 +117,8 @@ export const composeBuildContext = async (
         'react-dom': path.join(nodePath, 'react-dom'),
       },
     },
+
+    external: packageMetaContent?.blade?.external,
 
     plugins: [
       getFileListLoader(options?.virtualFiles),


### PR DESCRIPTION
This change adds a configuration property named `external`, which can be used to instruct Blade not to bundle certain dependencies that, for example, aren't compatible with serverless environments.

The configuration property can be defined in `package.json` like this:

```json
{
  "blade": {
    "external": ["a-package"]
  }
}
```

Documentation for this property will follow separately. First we must prove whether it even deserves to exist.