### PR TITLE
Ensure clarity for pagination cursors

### DIFF
--- a/docs/pages/hooks.mdx
+++ b/docs/pages/hooks.mdx
@@ -208,7 +208,7 @@ import SomeComponent from './components/test.client';
 const Page = () => {
     const accounts = use.accounts();
 
-    return <SomeComponent records={accounts} recordsNextPage={accounts.nextPage}>;
+    return <SomeComponent records={accounts} recordsNextPage={accounts.moreAfter}>;
 }
 ```
 
@@ -232,7 +232,7 @@ export const SomeComponent = ({ records, recordsNextPage }) => {
 The following options are available:
 
 ```tsx
-usePagination(nextPage, {
+usePagination(moreAfter, {
     // By default, a `?page` parameter will be added to the URL, which allows for sharing
     // the current pagination status of the page with other people. Setting this argument
     // to `false` will avoid that.
@@ -267,7 +267,7 @@ const Page = () => {
     const accounts = use.accounts();
 
     return (
-        <SomeComponent previousPage={accounts.previousPage} nextPage={accounts.nextPage}>
+        <SomeComponent moreBefore={accounts.moreBefore} moreAfter={accounts.moreAfter}>
             {accounts.map(account => <Row record={account} />)}
         </SomeComponent>;
     );
@@ -279,9 +279,9 @@ Within `SomeComponent` (which must be a client component, identified through `.c
 ```tsx
 import { usePagination, usePaginationBuffer } from 'blade/client/hooks';
 
-export const SomeComponent = ({ children: defaultChildren, nextPage, previousPage }) => {
-    const { paginate, resetPagination } = usePagination(nextPage);
-    const [children] = usePaginationBuffer(defaultChildren, { previousPage });
+export const SomeComponent = ({ children: defaultChildren, moreAfter, moreBefore }) => {
+    const { paginate, resetPagination } = usePagination(moreAfter);
+    const [children] = usePaginationBuffer(defaultChildren, { moreBefore });
 
     return <div>{children}</div>;
 };
@@ -294,7 +294,7 @@ The following options are available:
 ```tsx
 usePaginationBuffer(list, {
     // The pagination cursor for the previous page of your record list. Must be provided.
-    previousPage: '...',
+    moreBefore: '...',
 
     // By default, any changes to `list` will be reflected in the concatenated list
     // returned by `usePaginationBuffer()`. This default is useful because that means

--- a/docs/pages/hooks.mdx
+++ b/docs/pages/hooks.mdx
@@ -185,7 +185,19 @@ await add.account.with.handle('elaine', {
 
 ## `usePagination` (Client)
 
-Allows for paginating a read query and thereby modifies the result of the respective `use` hook associated with that read query.
+When retrieving multiple records (such as using `get.accounts()`), a maximum of 20 records are returned at once.
+
+This limit ensures that memory overflows are avoided by default. This means there cannot be a scenario where your Queries retrieve so many records that the memory available to your Blade application (which is determined by your cloud provider) fills up, and the application crashes.
+
+Furthermore, always returning the same amount of records within your application (rather than returning more records if there are more available) ensures consistent response times, as the response time does not depend on how many records are being provided. Like this, you will be able to track and improve your app’s performance much more easily.
+
+To retrieve more than 20 records, making use of “pagination” is advised, which means additional records are loaded on demand. If your application provides a UI, this may, for example, manifest in the following two ways:
+
+- The user looking at the list of Records may request more by clicking on “Next Page”.
+- The user looking at the list of Records may request more by scrolling downward.
+
+Which of these implementations (or any other) you may choose is up to you. The `usePagination` hook provides a function that you can
+call to easily load the next page without having to modify your query.
 
 For example, you might use the following read query in your page (on the server):
 

--- a/docs/pages/queries/instructions.mdx
+++ b/docs/pages/queries/instructions.mdx
@@ -99,68 +99,6 @@ use.accounts.with({
 });
 ```
 
-## Next Page (`after`)
-
-When running a Query such as `get.accounts` while more than 20 records are available for the respective model, a `moreAfter` property will be provided to you (the property only exists if more than 20 records are available; otherwise it is not defined).
-
-This property contains a so-called “cursor” pointing to the next page of records:
-
-```ts
-const accounts = use.accounts();
-
-// Contains the cursor of the next page.
-accounts.moreAfter;
-```
-
-Whenever you would like to load more records, you can then pass the value of `moreAfter` back to Blade, and you will be provided with the next 20 records:
-
-```ts
-const moreAccounts = use.accounts.after(accounts.moreAfter);
-
-// Contains the cursor of the next page.
-moreAccounts.moreAfter;
-```
-
-You can repeat the above as often as you want to until there are no more records available (in which case `moreAfter` will not be defined anymore). Every time you run the query, a new `moreAfter` cursor will be provided to you.
-
-## Previous Page (`before`)
-
-If you would like to implement bi-directional pagination, you may use the `before` instruction and its `moreBefore` counterpart, which behave exactly the same as `after` and `moreAfter`, except that they let you paginate “upwards” instead of “downwards”:
-
-```ts
-const moreAccounts = use.accounts.before(accounts.moreBefore);
-
-// Contains the cursor of the next page (upwards).
-moreAccounts.moreBefore;
-```
-
-For example, this would be useful if you’ve implemented a page that shows a specific range of records that still has more records before and after it in Blade, which aren’t displayed. You could then use `before` to reveal more of the “previous records” in the list.
-
-## Limited Amount (`limitedTo`)
-
-As mentioned above, by default, 20 records are provided per page and more records can be obtained by paginating them, meaning by loading more pages.
-
-However, in special cases in which you would like to retrieve more than 20 records from Blade without having to load multiple pages, you may decide to use the `limitedTo` instruction to provide a custom page length:
-
-```ts
-use.accounts.limitedTo(50);
-```
-
-As with other query instructions, `limitedTo` can be combined with the `after` and `before` instructions used for retrieving a specific page of records:
-
-```ts
-use.accounts({
-  after: '...',
-  limitedTo: 100,
-});
-```
-
-If you would like to display an infinite amount of records in your UI (for example displaying the list of members of a team in your app, which might be allowed to be infinite), we strongly recommend using pagination due to the reasons mentioned in the section above. In those cases, you should therefore only resort to `limitedTo` if you want to decrease or increase the page size slightly, not to retrieve all records.
-
-If, however, there is a guarantee within the conceptual model of your application that a certain kind of record can only exist a finite amount of times (or to be specific, only a finite amount or less than that is always displayed), you may decide to use `limitedTo` in order to retrieve all records at once.
-
-The maximum value allowed by `limitedTo` (the maximum page length) is `1000`. We strongly advice against making use of such a high value unless truly necessary.
-
 ## Ordering Records (`orderedBy`)
 
 Regardless of whether a singular or multiple records are being retrieved, the returned records will always be ordered by their creation date by default, meaning that the most recently created records will be returned first.
@@ -368,3 +306,64 @@ provided to the parent query and the sub query, determine whether to generate
 an SQL Join or an SQL Sub Query (since the Blade query syntax compiles to SQL),
 in order to maximize performance.
 
+## Next Page (`after`)
+
+When running a Query such as `get.accounts` while more than 20 records are available for the respective model, a `moreAfter` property will be provided to you (the property only exists if more than 20 records are available; otherwise it is not defined).
+
+This property contains a so-called “cursor” pointing to the next page of records:
+
+```ts
+const accounts = use.accounts();
+
+// Contains the cursor of the next page.
+accounts.moreAfter;
+```
+
+Whenever you would like to load more records, you can then pass the value of `moreAfter` back to Blade, and you will be provided with the next 20 records:
+
+```ts
+const moreAccounts = use.accounts.after(accounts.moreAfter);
+
+// Contains the cursor of the next page.
+moreAccounts.moreAfter;
+```
+
+You can repeat the above as often as you want to until there are no more records available (in which case `moreAfter` will not be defined anymore). Every time you run the query, a new `moreAfter` cursor will be provided to you.
+
+## Previous Page (`before`)
+
+If you would like to implement bi-directional pagination, you may use the `before` instruction and its `moreBefore` counterpart, which behave exactly the same as `after` and `moreAfter`, except that they let you paginate “upwards” instead of “downwards”:
+
+```ts
+const moreAccounts = use.accounts.before(accounts.moreBefore);
+
+// Contains the cursor of the next page (upwards).
+moreAccounts.moreBefore;
+```
+
+For example, this would be useful if you’ve implemented a page that shows a specific range of records that still has more records before and after it in Blade, which aren’t displayed. You could then use `before` to reveal more of the “previous records” in the list.
+
+## Limited Amount (`limitedTo`)
+
+As mentioned above, by default, 20 records are provided per page and more records can be obtained by paginating them, meaning by loading more pages.
+
+However, in special cases in which you would like to retrieve more than 20 records from Blade without having to load multiple pages, you may decide to use the `limitedTo` instruction to provide a custom page length:
+
+```ts
+use.accounts.limitedTo(50);
+```
+
+As with other query instructions, `limitedTo` can be combined with the `after` and `before` instructions used for retrieving a specific page of records:
+
+```ts
+use.accounts({
+  after: '...',
+  limitedTo: 100,
+});
+```
+
+If you would like to display an infinite amount of records in your UI (for example displaying the list of members of a team in your app, which might be allowed to be infinite), we strongly recommend using pagination due to the reasons mentioned in the section above. In those cases, you should therefore only resort to `limitedTo` if you want to decrease or increase the page size slightly, not to retrieve all records.
+
+If, however, there is a guarantee within the conceptual model of your application that a certain kind of record can only exist a finite amount of times (or to be specific, only a finite amount or less than that is always displayed), you may decide to use `limitedTo` in order to retrieve all records at once.
+
+The maximum value allowed by `limitedTo` (the maximum page length) is `1000`. We strongly advice against making use of such a high value unless truly necessary.

--- a/docs/pages/queries/instructions.mdx
+++ b/docs/pages/queries/instructions.mdx
@@ -99,23 +99,7 @@ use.accounts.with({
 });
 ```
 
-## Paginating Records (`before`, `after`, `limitedTo`)
-
-When retrieving multiple records (such as using `get.accounts()`), a maximum of 20 records are returned at once.
-
-This limit ensures that memory overflows are avoided by default. This means there cannot be a scenario where your Queries retrieve so many records that the memory available to the receiving application (such as a [Vercel Edge Function](https://vercel.com/docs/functions)]) fills up, and the application crashes.
-
-Furthermore, always returning the same amount of records within your application (rather than returning more records if there are more available) ensures consistent response times, as the response time does not depend on how many records are being provided. Like this, you will be able to track and improve your app’s performance much more easily.
-
-To retrieve more than 20 records, making use of “pagination” is advised, which means additional records are loaded on demand. If your application provides a UI, this may, for example, manifest in the following two ways:
-
-- The user looking at the list of Records may request more by clicking on “Next Page”.
-
-- The user looking at the list of Records may request more by scrolling downward.
-
-Which of these implementations (or any other) you may choose is up to you.
-
-### Next Page
+## Next Page (`after`)
 
 When running a Query such as `get.accounts` while more than 20 records are available for the respective model, a `moreAfter` property will be provided to you (the property only exists if more than 20 records are available; otherwise it is not defined).
 
@@ -139,7 +123,7 @@ moreAccounts.moreAfter;
 
 You can repeat the above as often as you want to until there are no more records available (in which case `moreAfter` will not be defined anymore). Every time you run the query, a new `moreAfter` cursor will be provided to you.
 
-### Previous Page
+## Previous Page (`before`)
 
 If you would like to implement bi-directional pagination, you may use the `before` instruction and its `moreBefore` counterpart, which behave exactly the same as `after` and `moreAfter`, except that they let you paginate “upwards” instead of “downwards”:
 
@@ -152,7 +136,7 @@ moreAccounts.moreBefore;
 
 For example, this would be useful if you’ve implemented a page that shows a specific range of records that still has more records before and after it in Blade, which aren’t displayed. You could then use `before` to reveal more of the “previous records” in the list.
 
-### Custom Page Length
+## Limited Amount (`limitedTo`)
 
 As mentioned above, by default, 20 records are provided per page and more records can be obtained by paginating them, meaning by loading more pages.
 

--- a/packages/blade/public/client/hooks.ts
+++ b/packages/blade/public/client/hooks.ts
@@ -263,8 +263,8 @@ export const useLinkEvents = (
 /**
  * Hook for paginating a list of records intelligently.
  *
- * @param nextPage - The pagination identifier provided for a list of records by `use`.
- * In the case of `const accounts = use.accounts();`, for example, `accounts.nextPage`
+ * @param moreAfter - The pagination identifier provided for a list of records by `use`.
+ * In the case of `const accounts = use.accounts();`, for example, `accounts.moreAfter`
  * should be passed.
  * @param options - A list of options for customizing the pagination behavior.
  * @param options.updateAddressBar - By default, a `?page` parameter will be added to the
@@ -274,7 +274,7 @@ export const useLinkEvents = (
  * @returns A function that can be invoked to load the next page.
  */
 export const usePagination = (
-  nextPage: string | null,
+  moreAfter: string | null,
   options?: Partial<Pick<PageFetchingOptions, 'updateAddressBar'>>,
 ): { paginate: () => void; resetPagination: () => void } => {
   const { transitionPage } = usePageTransition();
@@ -287,7 +287,7 @@ export const usePagination = (
   useEffect(() => {
     if (!loadingMore.current) return;
     loadingMore.current = false;
-  }, [nextPage]);
+  }, [moreAfter]);
 
   const resetPagination = () => {
     const privateLocation = privateLocationRef.current;
@@ -307,7 +307,7 @@ export const usePagination = (
     transitionPage(privateLocation.pathname + (params ? `?${params}` : ''));
   };
 
-  if (!nextPage) {
+  if (!moreAfter) {
     return {
       paginate: () => {
         console.debug(
@@ -332,7 +332,7 @@ export const usePagination = (
     // UI, so we're storing it inside a reference that persists across renders. Then the
     // address bar is updated in the effect above.
     const newSearchParams = new URLSearchParams(privateLocation.searchParams);
-    newSearchParams.set('page', nextPage);
+    newSearchParams.set('page', moreAfter);
     const newPath = `${privateLocation.pathname}?${newSearchParams.toString()}`;
 
     loadingMore.current = true;
@@ -349,7 +349,7 @@ export const usePagination = (
  *
  * @param items - An array of items (of any type) that should be accumulated. For example,
  * this could be a list of React children.
- * @param options.previousPage - The `previousPage` property of the record list that
+ * @param options.moreBefore - The `moreBefore` property of the record list that
  * should be paginated.
  * @param options.allowUpdates - Controls whether changes to the provided items should be
  * allowed, or if they should instead just be ignored.
@@ -358,9 +358,9 @@ export const usePagination = (
  */
 export const usePaginationBuffer = <T>(
   items: T[],
-  options: { previousPage?: string; allowUpdates?: boolean },
+  options: { moreBefore?: string; allowUpdates?: boolean },
 ): [T[], (factory: (prevState: T[]) => T[]) => void] => {
-  const { allowUpdates = true, previousPage: page } = options;
+  const { allowUpdates = true, moreBefore: page } = options;
 
   const [renderedChildren, setRenderedChildren] = useReduce<{
     buffered: boolean;

--- a/packages/blade/public/server/hooks.ts
+++ b/packages/blade/public/server/hooks.ts
@@ -89,14 +89,10 @@ const formatResult = (
 
   const resultArray = result as unknown[] & {
     // Properties that are exposed from the hook.
-    previousPage?: string;
-    nextPage?: string;
-    beforeAmount?: number;
-    afterAmount?: number;
-
-    // Properties that are only used internally.
     moreBefore?: string;
     moreAfter?: string;
+    beforeAmount?: number;
+    afterAmount?: number;
   };
 
   const paginationAmountQueryItem = queries.find((queryDetails) => {
@@ -116,17 +112,13 @@ const formatResult = (
   }
 
   if (resultArray.moreBefore) {
-    resultArray.previousPage = `${leafIndex}-${hookHash}-${queryIndex}-b-${resultArray.moreBefore}`;
-    if (targetModel) resultArray.previousPage += `-${targetModel}`;
-
-    delete resultArray.moreBefore;
+    resultArray.moreBefore = `${leafIndex}-${hookHash}-${queryIndex}-b-${resultArray.moreBefore}`;
+    if (targetModel) resultArray.moreBefore += `-${targetModel}`;
   }
 
   if (resultArray.moreAfter) {
-    resultArray.nextPage = `${leafIndex}-${hookHash}-${queryIndex}-a-${resultArray.moreAfter}`;
-    if (targetModel) resultArray.nextPage += `-${targetModel}`;
-
-    delete resultArray.moreAfter;
+    resultArray.moreAfter = `${leafIndex}-${hookHash}-${queryIndex}-a-${resultArray.moreAfter}`;
+    if (targetModel) resultArray.moreAfter += `-${targetModel}`;
   }
 
   return result;


### PR DESCRIPTION
So far, Blade has been using `previousPage` and `nextPage` as pagination cursors, while the underlying query client has been using `moreBefore` and `moreAfter` instead.

The change right here ensures that only `moreBefore` and `moreAfter` remain, to avoid multiple different properties that serve the same purpose.