### PR TITLE
Rename `.ronin` config dir to `.blade`

### DIFF
--- a/packages/blade-cli/src/commands/types.ts
+++ b/packages/blade-cli/src/commands/types.ts
@@ -5,7 +5,7 @@ import { generate } from 'blade-codegen';
 import { generateZodSchema } from 'blade-codegen/zod';
 import { CompilerError } from 'blade-compiler';
 
-import type { BaseFlags } from '@/src/utils/misc';
+import { BLADE_CONFIG_DIR, type BaseFlags } from '@/src/utils/misc';
 import { getModels } from '@/src/utils/model';
 import { spinner as ora } from '@/src/utils/spinner';
 import {
@@ -30,7 +30,7 @@ export default async (
   const spinner = ora.info(flags?.zod ? 'Generating Zod schemas' : 'Generating types');
 
   try {
-    const configDir = path.join(process.cwd(), '.ronin');
+    const configDir = path.join(process.cwd(), BLADE_CONFIG_DIR);
     const configDirExists = await fs
       .stat(configDir)
       .then(() => true)

--- a/packages/blade-cli/src/utils/config.ts
+++ b/packages/blade-cli/src/utils/config.ts
@@ -1,13 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
+import { BLADE_CONFIG_DIR } from '@/src/utils/misc';
+
 interface Config {
   space?: string;
   modelsDir?: string;
 }
 
 export const saveConfig = (config: Config): string => {
-  const configDir = path.join(process.cwd(), '.ronin');
+  const configDir = path.join(process.cwd(), BLADE_CONFIG_DIR);
 
   if (!fs.existsSync(configDir)) {
     fs.mkdirSync(configDir, { recursive: true });
@@ -26,7 +28,7 @@ export const saveConfig = (config: Config): string => {
 };
 
 export const resetConfig = (): void => {
-  const configPath = path.join(process.cwd(), '.ronin', 'config.json');
+  const configPath = path.join(process.cwd(), BLADE_CONFIG_DIR, 'config.json');
 
   if (fs.existsSync(configPath)) {
     fs.unlinkSync(configPath);
@@ -34,7 +36,7 @@ export const resetConfig = (): void => {
 };
 
 export const readConfig = (): Config => {
-  const configPath = path.join(process.cwd(), '.ronin', 'config.json');
+  const configPath = path.join(process.cwd(), BLADE_CONFIG_DIR, 'config.json');
 
   if (!fs.existsSync(configPath)) {
     return {};

--- a/packages/blade-cli/src/utils/misc.ts
+++ b/packages/blade-cli/src/utils/misc.ts
@@ -38,7 +38,7 @@ export const BASE_FLAGS = {
 export type BaseFlags = Record<keyof typeof BASE_FLAGS, boolean | undefined>;
 
 /** Directory containing RONIN configuration files */
-export const RONIN_CONFIG_DIR = '.ronin';
+export const BLADE_CONFIG_DIR = '.blade';
 
 /** Directory containing RONIN model definitions */
 export const MODELS_IN_CODE_DIR = 'schema';
@@ -55,7 +55,7 @@ export const MODEL_IN_CODE_PATH = path.resolve(
 /** Directory containing RONIN migrations */
 export const MIGRATIONS_PATH = path.resolve(
   process.cwd(),
-  RONIN_CONFIG_DIR,
+  BLADE_CONFIG_DIR,
   'migrations',
 );
 

--- a/packages/blade-cli/src/utils/types.ts
+++ b/packages/blade-cli/src/utils/types.ts
@@ -2,20 +2,22 @@ import fs from 'node:fs/promises';
 
 import json5 from 'json5';
 
+import { BLADE_CONFIG_DIR } from '@/src/utils/misc';
+
 /**
- * The name of the TypeScript declaration file stored inside the `.ronin` directory.
+ * The name of the TypeScript declaration file stored inside the `.blade` directory.
  */
 export const TYPES_DTS_FILE_NAME = 'types.d.ts';
 
 /**
- * The name of the Zod schemas file stored inside the `.ronin` directory.
+ * The name of the Zod schemas file stored inside the `.blade` directory.
  */
 export const ZOD_SCHEMA_FILE_NAME = 'zod.ts';
 
 /**
- * The name of the TypeScript declaration file stored inside the `.ronin` directory.
+ * The name of the TypeScript declaration file stored inside the `.blade` directory.
  */
-const TYPES_INCLUDE_PATH = '.ronin/*.d.ts';
+const TYPES_INCLUDE_PATH = `${BLADE_CONFIG_DIR}/*.d.ts`;
 
 /**
  * Add the path to the generated TypeScript types to the `tsconfig.json` file.

--- a/packages/blade-cli/tests/index.test.ts
+++ b/packages/blade-cli/tests/index.test.ts
@@ -197,7 +197,7 @@ describe('CLI', () => {
 
         // Mock file operations
         spyOn(fs, 'existsSync').mockImplementation(
-          (path) => !path.toString().includes('.ronin/db.sqlite'),
+          (path) => !path.toString().includes('.blade/db.sqlite'),
         );
         spyOn(path, 'resolve').mockReturnValue(
           path.join(process.cwd(), 'tests/fixtures/migration-fixture.ts'),
@@ -264,7 +264,7 @@ describe('CLI', () => {
         ],
       );
       spyOn(fs, 'existsSync').mockImplementation(
-        (path) => !path.toString().includes('.ronin/db.sqlite'),
+        (path) => !path.toString().includes('.blade/db.sqlite'),
       );
       spyOn(path, 'resolve').mockReturnValue(
         path.join(process.cwd(), 'tests/fixtures/migration-fixture.ts'),
@@ -569,7 +569,7 @@ describe('CLI', () => {
         spyOn(fs, 'existsSync').mockImplementation(
           (path) =>
             path.toString().includes('migration-fixture.ts') ||
-            path.toString().includes('.ronin/migrations'),
+            path.toString().includes('.blade/migrations'),
         );
         spyOn(selectModule, 'select').mockResolvedValue('migration-0001.ts');
         spyOn(path, 'resolve').mockReturnValue(
@@ -654,7 +654,7 @@ describe('CLI', () => {
         spyOn(fs, 'existsSync').mockImplementation(
           (path) =>
             path.toString().includes('migration-fixture.ts') ||
-            path.toString().includes('.ronin/migrations'),
+            path.toString().includes('.blade/migrations'),
         );
         spyOn(selectModule, 'select').mockResolvedValue('migration-0001.ts');
         spyOn(path, 'resolve').mockReturnValue(
@@ -703,7 +703,7 @@ describe('CLI', () => {
         ]);
 
         spyOn(fs, 'existsSync').mockImplementation((path) =>
-          path.toString().includes('.ronin/migrations'),
+          path.toString().includes('.blade/migrations'),
         );
 
         await run({ version: '1.0.0' });

--- a/packages/blade-cli/tests/utils/config.test.ts
+++ b/packages/blade-cli/tests/utils/config.test.ts
@@ -2,9 +2,10 @@ import { afterEach, beforeAll, describe, expect, jest, mock, test } from 'bun:te
 import fs from 'node:fs';
 import path from 'node:path';
 import { readConfig, resetConfig, saveConfig } from '@/src/utils/config';
+import { BLADE_CONFIG_DIR } from '@/src/utils/misc';
 
 describe('config', () => {
-  const configDir = path.join(process.cwd(), '.ronin');
+  const configDir = path.join(process.cwd(), BLADE_CONFIG_DIR);
   const configPath = path.join(configDir, 'config.json');
 
   beforeAll(() => {

--- a/packages/blade-cli/tests/utils/protocol.test.ts
+++ b/packages/blade-cli/tests/utils/protocol.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, jest, spyOn, test } from 'bun:test';
 import fs, { type PathOrFileDescriptor } from 'node:fs';
+import { BLADE_CONFIG_DIR } from '@/src/utils/misc';
 import { Protocol } from '@/src/utils/protocol';
 import type { Model, Statement } from 'blade-compiler';
 
@@ -34,7 +35,7 @@ describe('protocol', () => {
       data: string | NodeJS.ArrayBufferView,
     ): void => {
       writeFileSyncCalled = true;
-      expect(path).toBe(`${process.cwd()}/.ronin/migrations/${fileName}.ts`);
+      expect(path).toBe(`${process.cwd()}/${BLADE_CONFIG_DIR}/migrations/${fileName}.ts`);
       expect(data).toContain(
         'create.model.to({ slug: "my_model", pluralSlug: "my_models" })',
       );
@@ -71,7 +72,9 @@ describe('protocol', () => {
       data: string | ArrayBufferView,
     ): void => {
       writeFileSyncCalled = true;
-      expect(path).toBe(`${process.cwd()}/.ronin/migrations/${fileName}.sql`);
+      expect(path).toBe(
+        `${process.cwd()}/${BLADE_CONFIG_DIR}/migrations/${fileName}.sql`,
+      );
       expect(data).toBe('CREATE SCHEMA my_schema;');
     };
 

--- a/packages/blade-cli/tests/utils/pull.test.ts
+++ b/packages/blade-cli/tests/utils/pull.test.ts
@@ -178,7 +178,7 @@ describe('command', () => {
     spyOn(modelModule, 'getModels').mockResolvedValue([]);
 
     try {
-      await pull(undefined, undefined);
+      await pull(undefined);
     } catch (error) {
       expect(error).toBeInstanceOf(Error);
       // @ts-expect-error This is a mock.
@@ -201,7 +201,7 @@ describe('command', () => {
       },
     ]);
 
-    await pull(undefined, undefined);
+    await pull(undefined);
 
     // Verify file was created in temp directory.
     const fileExists = await fs.exists(MODEL_IN_CODE_PATH);
@@ -235,7 +235,7 @@ describe('command', () => {
       },
     ]);
 
-    await pull(undefined, undefined);
+    await pull(undefined);
 
     const fileExists = await fs.exists(MODEL_IN_CODE_PATH);
 
@@ -268,7 +268,7 @@ describe('command', () => {
       },
     ]);
 
-    await pull(undefined, undefined);
+    await pull(undefined);
 
     const fileExists = await fs.exists(MODEL_IN_CODE_PATH);
 
@@ -302,7 +302,7 @@ export const User = model({
       },
     ]);
 
-    await pull(undefined, undefined);
+    await pull(undefined);
 
     const fileExists = await fs.exists(MODEL_IN_CODE_PATH);
 

--- a/packages/blade-cli/tests/utils/types.test.ts
+++ b/packages/blade-cli/tests/utils/types.test.ts
@@ -25,7 +25,7 @@ describe('types utils', () => {
 
       expect(config).toMatchObject({
         compilerOptions: {},
-        include: ['**/*.ts', '**/*.tsx', '.ronin/*.d.ts'],
+        include: ['**/*.ts', '**/*.tsx', '.blade/*.d.ts'],
       });
     });
 
@@ -43,7 +43,7 @@ describe('types utils', () => {
 
       expect(config).toMatchObject({
         compilerOptions: {},
-        include: ['**/*.ts', '**/*.tsx', '.ronin/*.d.ts'],
+        include: ['**/*.ts', '**/*.tsx', '.blade/*.d.ts'],
       });
     });
 
@@ -62,7 +62,7 @@ describe('types utils', () => {
 
       expect(config).toMatchObject({
         compilerOptions: {},
-        include: ['src/**/*', '.ronin/*.d.ts'],
+        include: ['src/**/*', '.blade/*.d.ts'],
       });
     });
 
@@ -81,7 +81,7 @@ describe('types utils', () => {
 
       expect(config).toMatchObject({
         compilerOptions: {},
-        include: ['**/*.ts', '**/*.tsx', '.ronin/*.d.ts'],
+        include: ['**/*.ts', '**/*.tsx', '.blade/*.d.ts'],
       });
     });
   });


### PR DESCRIPTION
This change renames the `.ronin` config directory to instead be called `.blade`. Along with this comes some minor refactoring to use a shared constant for this directory name.