### PR TITLE
Inline record default values

### DIFF
--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -74,6 +74,9 @@ export const runQueries = async <T extends ResultRecord>(
     const transaction = new Transaction(rawQueries, {
       models: options.models,
       defaultRecordLimit: options.defaultRecordLimit,
+
+      // Hive doesn't support non-deterministic default values at the moment.
+      inlineDefaults: true,
     });
 
     const token = options.token as string;


### PR DESCRIPTION
This is needed in order for default values of records (such as IDs) to be generated in a consistent manner.