### PR TITLE
Removed `useMutationResult` hook

### DIFF
--- a/docs/pages/hooks.mdx
+++ b/docs/pages/hooks.mdx
@@ -528,20 +528,6 @@ useMetadata({
 });
 ```
 
-## `useMutationResult` (Server)
-
-Since Blade requires data to be read only on the server and data to be mutated only on the client, the result of a mutation is only accessible as a result of the respective [mutation call](#usemutation-client). 
-
-In scenarios where you must explicitly access the result of a mutation on the server, however (for example in order to [set](#usecookie-server) HTTP-only cookies), you may invoke `useMutationResult()` on the server to retrieve its result.
-
-This interface will likely be moved into a different position within the programmatic API in the future.
-
-```tsx
-import { useMutationResult } from 'blade/server/hooks';
-
-const updatedRecords = useMutationResult();
-```
-
 ## `useJWT` (Server)
 
 Allows for parsing [JSON Web Tokens](https://jwt.io) without blocking the page render.

--- a/packages/blade/public/server/hooks.ts
+++ b/packages/blade/public/server/hooks.ts
@@ -311,12 +311,4 @@ const useJWT = <T>(...args: Parameters<typeof verify>): T => {
   };
 };
 
-const useMutationResult = <T>(): T => {
-  const serverContext = useContext(RootServerContext);
-  if (!serverContext) throw new Error('Missing server context in `useMutationResult`');
-  const { queries } = serverContext.collected;
-
-  return queries.filter(({ type }) => type === 'write').map(({ result }) => result) as T;
-};
-
-export { use, useCountOf, useListOf, useBatch, useMutationResult, useMetadata, useJWT };
+export { use, useCountOf, useListOf, useBatch, useMetadata, useJWT };


### PR DESCRIPTION
This hook has been destined to be removed for a very long time, and I decided that now is a good time to do so.

The last valid use case for it was setting cookies as a result of mutations, which is a responsibility that triggers will take over for the time being.