### PR TITLE
Removed `useJWT` hook

### DIFF
--- a/docs/pages/hooks.mdx
+++ b/docs/pages/hooks.mdx
@@ -527,29 +527,3 @@ useMetadata({
     bodyClassName: 'text-gray-800'
 });
 ```
-
-## `useJWT` (Server)
-
-Allows for parsing [JSON Web Tokens](https://jwt.io) without blocking the page render.
-
-```tsx
-import { useJWT } from 'blade/server/hooks';
-
-const payload = useJWT(token, secret);
-```
-
-You may also decide to pass a TypeScript generic with the type of payload:
-
-```tsx
-interface SessionToken {
-    iss: string;
-    sub: string;
-    aud: string;
-    iat?: number | undefined;
-    exp?: number | undefined;
-};
-
-useJWT<SessionToken>(token, secret);
-```
-
-If the same JSON Web Token is parsed in different layouts surrounding a page or the page itself (this would happen if you place the hook in a shared utility hook in your app, for example), the token will only be parsed once and all instances of the hook will return its payload. In other words, JWTs are deduped across layouts and pages.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -59,11 +59,15 @@ API of Blade revolves around the concept of [Hooks](https://react.dev/reference/
 - `useNavigator`: Mimics `window.navigator`
 - `useRedirect`: Change the page
 - `useCookie`: Read and write cookies
-- `useJWT`: Read JSON Web Tokens
 - `useParams`: Read dynamic path segments
 - `usePopulatePathname`: Populate dynamic path segments
 - `usePagination`: Get the next/previous page of records
 - `usePaginationBuffer`: Concatenate paginated lists
+- `useMetadata`: Set the contents of `<head>`
+- `useCountOf`: Like `use`, but counts records
+- `useBatch`: Run multiple `use` queries at once
+- `useLinkEvents`: Applies the event handlers of the `<Link>` component
+- `useQueryState`: Like `useState`, but for URL query params
 
 ## Get Started
 

--- a/packages/blade/public/server/hooks.ts
+++ b/packages/blade/public/server/hooks.ts
@@ -290,25 +290,4 @@ const useBatch = (<T extends [any, ...any[]]>(
   queryOptions?: Record<string, unknown>,
 ) => PromiseTuple<T>;
 
-const useJWT = <T>(...args: Parameters<typeof verify>): T => {
-  const [token, secret, algo] = args;
-
-  const serverContext = useContext(RootServerContext);
-  if (!serverContext) throw new Error('Missing server context in `useJWT`');
-  const result = serverContext.collected.jwts[token];
-
-  if (result?.decodedPayload) {
-    if (result.decodedPayload instanceof Error) throw result.decodedPayload;
-    return result.decodedPayload as T;
-  }
-
-  throw {
-    __blade_jwt: {
-      token,
-      secret,
-      algo,
-    },
-  };
-};
-
-export { use, useCountOf, useListOf, useBatch, useMetadata, useJWT };
+export { use, useCountOf, useListOf, useBatch, useMetadata };


### PR DESCRIPTION
Similar to `useMutationResult` in https://github.com/ronin-co/blade/pull/474, the `useJWT` hook has been destined to be removed for a long time, and I've concluded that now is the right time to do so.

Its responsibilities will be taken over by `verifyJWT`, which landed in https://github.com/ronin-co/blade/pull/473.