### PR TITLE
Removed unnecessary export path

### DIFF
--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -26,8 +26,7 @@
     "./server/utils/*": "./dist/public/server/utils/*.js",
     "./hooks": "./dist/public/universal/hooks.js",
     "./schema": "./dist/public/universal/schema.js",
-    "./types": "./dist/public/universal/types.js",
-    "./utils": "./dist/public/universal/utils.js"
+    "./types": "./dist/public/universal/types.js"
   },
   "typesVersions": {
     "*": {


### PR DESCRIPTION
This was missing from https://github.com/ronin-co/blade/pull/472 and removes an export that is no longer used!