### PR TITLE
Make cookies available for subsequent triggers

### DIFF
--- a/packages/blade/private/server/worker/triggers.ts
+++ b/packages/blade/private/server/worker/triggers.ts
@@ -28,7 +28,7 @@ export const prepareTriggers = (
 ): TriggersList => {
   const options: Partial<NewTriggerOptions> = {
     cookies: serverContext.cookies,
-    setCookie: getCookieSetter(serverContext.collected),
+    setCookie: getCookieSetter(serverContext),
     navigator: {
       userAgent: serverContext.userAgent,
       geoLocation: serverContext.geoLocation,

--- a/packages/blade/private/universal/utils/index.ts
+++ b/packages/blade/private/universal/utils/index.ts
@@ -35,13 +35,13 @@ interface CookieOptions {
 /**
  * Generates a function that can be used to set new cookies.
  *
- * @param collected - The list of all collected resources in the server context.
+ * @param serverContext - A server context object.
  *
  * @returns The function that can be used for setting cookies.
  */
-export const getCookieSetter = <T>(
-  collected: ServerContext['collected'],
-): SetCookie<T> => {
+export const getCookieSetter = <T>(serverContext: ServerContext): SetCookie<T> => {
+  const { collected, cookies } = serverContext;
+
   return (name, value, options) => {
     const cookieSettings: CookieSerializeOptions = {
       // 365 days.
@@ -54,6 +54,9 @@ export const getCookieSetter = <T>(
     if (value === null) {
       cookieSettings.expires = new Date(Date.now() - 1000000);
       delete cookieSettings.maxAge;
+
+      // Remove the cookie from the current list.
+      delete cookies[name];
     }
     // As per the types defined for the surrounding function, this condition would never
     // be met. But we'd like to keep it regardless, to catch cases where the types
@@ -71,5 +74,8 @@ export const getCookieSetter = <T>(
       value: value as string | null,
       ...cookieSettings,
     };
+
+    // Make the cookie available in the current list.
+    cookies[name] = value as string;
   };
 };

--- a/packages/blade/public/universal/hooks.ts
+++ b/packages/blade/public/universal/hooks.ts
@@ -101,11 +101,11 @@ const useCookie = <T extends string | null>(
     const serverContext = useContext(RootServerContext);
     if (!serverContext) throw new Error('Missing server context in `useCookie`');
 
-    const { cookies, collected } = serverContext;
+    const { cookies } = serverContext;
     const value = cookies[name] as T | null;
 
     const setValue: SetExistingCookie<T> = (value, options) => {
-      return getCookieSetter(collected)(name, value, options);
+      return getCookieSetter(serverContext)(name, value, options);
     };
 
     return [value, setValue];


### PR DESCRIPTION
This change ensures that, if a trigger sets a cookie, triggers that run after it can see the cookie.