### PR TITLE
Simplify migration protocols

### DIFF
--- a/packages/blade-cli/src/utils/protocol.ts
+++ b/packages/blade-cli/src/utils/protocol.ts
@@ -115,7 +115,7 @@ export class Protocol {
 
     return `${imports}
     
-export default () => [
+export default [
   ${this._roninQueries.map((query) => ` ${query}`).join(',\n')}
 ];`;
   };

--- a/packages/blade-cli/tests/fixtures/migration-fixture.ts
+++ b/packages/blade-cli/tests/fixtures/migration-fixture.ts
@@ -1,6 +1,6 @@
 import { create } from 'blade/schema';
 
-export default () => [
+export default [
   create.model({
     slug: 'user',
     fields: {

--- a/packages/blade-cli/tests/fixtures/protocol.ts
+++ b/packages/blade-cli/tests/fixtures/protocol.ts
@@ -1,4 +1,4 @@
 import { get } from 'blade/schema';
 
 // biome-ignore lint/nursery/useExplicitType: In a real scenario, there is no type.
-export default () => [get.account.with({ handle: 'elaine' })];
+export default [get.account.with({ handle: 'elaine' })];

--- a/packages/blade-cli/tests/index.test.ts
+++ b/packages/blade-cli/tests/index.test.ts
@@ -459,7 +459,7 @@ describe('CLI', () => {
         console.error(writeFileSyncSpy.mock.calls);
 
         expect(writeFileSyncSpy.mock.calls[0][1]).toContain(
-          `import { drop } from \"blade/schema\";\n\nexport default () => [\n  drop.model(\"user\"),\n];\n`,
+          `import { drop } from \"blade/schema\";\n\nexport default [\n  drop.model(\"user\"),\n];\n`,
         );
       });
 


### PR DESCRIPTION
This change applies the following syntax change for migration protocols:

```typescript
// Current migration protocols
export default () => [...queries..];

// New migration protocols
export default [...queries..];
```