### PR TITLE
Improve `with` query typed fields

### DIFF
--- a/packages/blade-codegen/src/declarations.ts
+++ b/packages/blade-codegen/src/declarations.ts
@@ -932,6 +932,8 @@ export const selectingQueryPromiseType = factory.createTypeAliasDeclaration(
 );
 
 /**
+ * @todo(@nurodev): Replace `Partial<S> | CombinedInstructions["with"]` with utility to map advanced assertions
+ *
  * @example
  * ```ts
  * type WithQuery<U, S> = ReducedFunction & {
@@ -1087,6 +1089,8 @@ export const withQueryType = factory.createTypeAliasDeclaration(
 );
 
 /**
+ * @todo(@nurodev): Replace `Partial<S> | CombinedInstructions["with"]` with utility to map advanced assertions
+ *
  * @example
  * ```ts
  * type WithQueryPromise<U, S> = ReducedFunction & {

--- a/packages/blade-codegen/src/declarations.ts
+++ b/packages/blade-codegen/src/declarations.ts
@@ -934,8 +934,8 @@ export const selectingQueryPromiseType = factory.createTypeAliasDeclaration(
 /**
  * @example
  * ```ts
- * type WithQuery<U> = ReducedFunction & {
- *  <T = U>(instructions: CombinedInstructions["with"], options?: Record<string, unknown>): T;
+ * type WithQuery<U, S> = ReducedFunction & {
+ *  <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): T;
  *  id: <T = U>(value: ResultRecord["id"], options?: Record<string, unknown>) => T;
  *  ronin: ReducedFunction & {
  *    createdAt: <T = U>(value: ResultRecord["ronin"]["createdAt"], options?: Record<string, unknown>) => T;
@@ -949,13 +949,16 @@ export const selectingQueryPromiseType = factory.createTypeAliasDeclaration(
 export const withQueryType = factory.createTypeAliasDeclaration(
   undefined,
   identifiers.namespace.utils.withQuery,
-  [factory.createTypeParameterDeclaration(undefined, typeArgumentIdentifiers.using)],
+  [
+    factory.createTypeParameterDeclaration(undefined, typeArgumentIdentifiers.using),
+    factory.createTypeParameterDeclaration(undefined, typeArgumentIdentifiers.schema),
+  ],
   factory.createIntersectionTypeNode([
     factory.createTypeReferenceNode(identifiers.blade.reducedFunction),
     factory.createTypeLiteralNode([
       /**
        * ```ts
-       * <T = User | null>(options: CombinedInstructions["with"]): T
+       * <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): T
        * ```
        */
       factory.createCallSignature(
@@ -973,10 +976,17 @@ export const withQueryType = factory.createTypeAliasDeclaration(
             undefined,
             'instructions',
             undefined,
-            factory.createIndexedAccessTypeNode(
-              factory.createTypeReferenceNode(identifiers.compiler.combinedInstructions),
-              factory.createLiteralTypeNode(factory.createStringLiteral('with')),
-            ),
+            factory.createUnionTypeNode([
+              factory.createTypeReferenceNode(identifiers.primitive.partial, [
+                factory.createTypeReferenceNode(typeArgumentIdentifiers.schema),
+              ]),
+              factory.createIndexedAccessTypeNode(
+                factory.createTypeReferenceNode(
+                  identifiers.compiler.combinedInstructions,
+                ),
+                factory.createLiteralTypeNode(factory.createStringLiteral('with')),
+              ),
+            ]),
           ),
           sharedQueryOptionsParameter,
         ],
@@ -1079,8 +1089,8 @@ export const withQueryType = factory.createTypeAliasDeclaration(
 /**
  * @example
  * ```ts
- * type WithQueryPromise<U> = ReducedFunction & {
- *  <T = U>(instructions: CombinedInstructions["with"], options?: Record<string, unknown>): Promise<T>;
+ * type WithQueryPromise<U, S> = ReducedFunction & {
+ *  <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): Promise<T>;
  *  id: <T = U>(value: ResultRecord["id"], options?: Record<string, unknown>) => Promise<T>;
  *  ronin: ReducedFunction & {
  *    createdAt: <T = U>(value: ResultRecord["ronin"]["createdAt"], options?: Record<string, unknown>) => Promise<T>;
@@ -1094,13 +1104,16 @@ export const withQueryType = factory.createTypeAliasDeclaration(
 export const withQueryPromiseType = factory.createTypeAliasDeclaration(
   undefined,
   identifiers.namespace.utils.withQueryPromise,
-  [factory.createTypeParameterDeclaration(undefined, typeArgumentIdentifiers.using)],
+  [
+    factory.createTypeParameterDeclaration(undefined, typeArgumentIdentifiers.using),
+    factory.createTypeParameterDeclaration(undefined, typeArgumentIdentifiers.schema),
+  ],
   factory.createIntersectionTypeNode([
     factory.createTypeReferenceNode(identifiers.blade.reducedFunction),
     factory.createTypeLiteralNode([
       /**
        * ```ts
-       * <T = User | null>(options: CombinedInstructions["with"]): T
+       * <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): Promise<T>
        * ```
        */
       factory.createCallSignature(
@@ -1118,10 +1131,17 @@ export const withQueryPromiseType = factory.createTypeAliasDeclaration(
             undefined,
             'instructions',
             undefined,
-            factory.createIndexedAccessTypeNode(
-              factory.createTypeReferenceNode(identifiers.compiler.combinedInstructions),
-              factory.createLiteralTypeNode(factory.createStringLiteral('with')),
-            ),
+            factory.createUnionTypeNode([
+              factory.createTypeReferenceNode(identifiers.primitive.partial, [
+                factory.createTypeReferenceNode(typeArgumentIdentifiers.schema),
+              ]),
+              factory.createIndexedAccessTypeNode(
+                factory.createTypeReferenceNode(
+                  identifiers.compiler.combinedInstructions,
+                ),
+                factory.createLiteralTypeNode(factory.createStringLiteral('with')),
+              ),
+            ]),
           ),
           sharedQueryOptionsParameter,
         ],

--- a/packages/blade-codegen/src/generators/syntax.ts
+++ b/packages/blade-codegen/src/generators/syntax.ts
@@ -198,7 +198,12 @@ export const generateWithSyntax = (
     factory.createIntersectionTypeNode([
       factory.createTypeReferenceNode(
         factory.createQualifiedName(identifiers.namespace.utils.name, name),
-        [modelNode],
+        [
+          modelNode,
+          factory.createTypeReferenceNode(
+            factory.createIdentifier(convertToPascalCase(model.slug)),
+          ),
+        ],
       ),
       factory.createTypeLiteralNode(
         modelUserFieldEntries.map(([slug, field]) => {

--- a/packages/blade-codegen/tests/__snapshots__/index.test.ts.snap
+++ b/packages/blade-codegen/tests/__snapshots__/index.test.ts.snap
@@ -32,8 +32,8 @@ declare namespace Utils {
     type RootQueryCallerPromise<U> = <T = U>(instructions?: Partial<CombinedInstructions>, options?: Record<string, unknown>) => Promise<T>;
     type SelectingQuery<U, F> = ReducedFunction & (<T = U>(instructions: Array<F>, options?: Record<string, unknown>) => T);
     type SelectingQueryPromise<U, F> = ReducedFunction & (<T = U>(instructions: Array<F>, options?: Record<string, unknown>) => Promise<T>);
-    type WithQuery<U> = ReducedFunction & {
-        <T = U>(instructions: CombinedInstructions["with"], options?: Record<string, unknown>): T;
+    type WithQuery<U, S> = ReducedFunction & {
+        <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): T;
         id: <T = U>(value: ResultRecord["id"], options?: Record<string, unknown>) => T;
         ronin: ReducedFunction & {
             createdAt: <T = U>(value: ResultRecord["ronin"]["createdAt"], options?: Record<string, unknown>) => T;
@@ -42,8 +42,8 @@ declare namespace Utils {
             updatedBy: <T = U>(value: ResultRecord["ronin"]["updatedBy"], options?: Record<string, unknown>) => T;
         };
     };
-    type WithQueryPromise<U> = ReducedFunction & {
-        <T = U>(instructions: CombinedInstructions["with"], options?: Record<string, unknown>): Promise<T>;
+    type WithQueryPromise<U, S> = ReducedFunction & {
+        <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): Promise<T>;
         id: <T = U>(value: ResultRecord["id"], options?: Record<string, unknown>) => Promise<T>;
         ronin: ReducedFunction & {
             createdAt: <T = U>(value: ResultRecord["ronin"]["createdAt"], options?: Record<string, unknown>) => Promise<T>;
@@ -75,11 +75,11 @@ declare namespace Syntax {
             type ToQueryPromise = any;
             type UsingQuery = ReducedFunction & (<T = Account | null>(value: CombinedInstructions["using"]) => T);
             type UsingQueryPromise = ReducedFunction & (<T = Account | null>(value: CombinedInstructions["using"]) => Promise<T>);
-            type WithQuery = Utils.WithQuery<Account | null> & {
+            type WithQuery = Utils.WithQuery<Account | null, Account> & {
                 name: <T = Account | null>(name: Account["name"], options?: Record<string, unknown>) => T;
                 email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => T;
             };
-            type WithQueryPromise = Utils.WithQueryPromise<Account | null> & {
+            type WithQueryPromise = Utils.WithQueryPromise<Account | null, Account> & {
                 name: <T = Account | null>(name: Account["name"], options?: Record<string, unknown>) => Promise<T>;
                 email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
             };
@@ -103,11 +103,11 @@ declare namespace Syntax {
             type ToQueryPromise = any;
             type UsingQuery = ReducedFunction & (<T = Accounts>(value: CombinedInstructions["using"]) => T);
             type UsingQueryPromise = ReducedFunction & (<T = Accounts>(value: CombinedInstructions["using"]) => Promise<T>);
-            type WithQuery = Utils.WithQuery<Accounts> & {
+            type WithQuery = Utils.WithQuery<Accounts, Account> & {
                 name: <T = Accounts>(name: Account["name"], options?: Record<string, unknown>) => T;
                 email: <T = Accounts>(email: Account["email"], options?: Record<string, unknown>) => T;
             };
-            type WithQueryPromise = Utils.WithQueryPromise<Accounts> & {
+            type WithQueryPromise = Utils.WithQueryPromise<Accounts, Account> & {
                 name: <T = Accounts>(name: Account["name"], options?: Record<string, unknown>) => Promise<T>;
                 email: <T = Accounts>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
             };
@@ -268,8 +268,8 @@ declare namespace Utils {
     type RootQueryCallerPromise<U> = <T = U>(instructions?: Partial<CombinedInstructions>, options?: Record<string, unknown>) => Promise<T>;
     type SelectingQuery<U, F> = ReducedFunction & (<T = U>(instructions: Array<F>, options?: Record<string, unknown>) => T);
     type SelectingQueryPromise<U, F> = ReducedFunction & (<T = U>(instructions: Array<F>, options?: Record<string, unknown>) => Promise<T>);
-    type WithQuery<U> = ReducedFunction & {
-        <T = U>(instructions: CombinedInstructions["with"], options?: Record<string, unknown>): T;
+    type WithQuery<U, S> = ReducedFunction & {
+        <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): T;
         id: <T = U>(value: ResultRecord["id"], options?: Record<string, unknown>) => T;
         ronin: ReducedFunction & {
             createdAt: <T = U>(value: ResultRecord["ronin"]["createdAt"], options?: Record<string, unknown>) => T;
@@ -278,8 +278,8 @@ declare namespace Utils {
             updatedBy: <T = U>(value: ResultRecord["ronin"]["updatedBy"], options?: Record<string, unknown>) => T;
         };
     };
-    type WithQueryPromise<U> = ReducedFunction & {
-        <T = U>(instructions: CombinedInstructions["with"], options?: Record<string, unknown>): Promise<T>;
+    type WithQueryPromise<U, S> = ReducedFunction & {
+        <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): Promise<T>;
         id: <T = U>(value: ResultRecord["id"], options?: Record<string, unknown>) => Promise<T>;
         ronin: ReducedFunction & {
             createdAt: <T = U>(value: ResultRecord["ronin"]["createdAt"], options?: Record<string, unknown>) => Promise<T>;
@@ -311,12 +311,12 @@ declare namespace Syntax {
             type ToQueryPromise = any;
             type UsingQuery = ReducedFunction & (<T = Account | null>(value: CombinedInstructions["using"]) => T);
             type UsingQueryPromise = ReducedFunction & (<T = Account | null>(value: CombinedInstructions["using"]) => Promise<T>);
-            type WithQuery = Utils.WithQuery<Account | null> & {
+            type WithQuery = Utils.WithQuery<Account | null, Account> & {
                 name: <T = Account | null>(name: Account["name"], options?: Record<string, unknown>) => T;
                 email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => T;
                 image: <T = Account | null>(image: Account["image"], options?: Record<string, unknown>) => T;
             };
-            type WithQueryPromise = Utils.WithQueryPromise<Account | null> & {
+            type WithQueryPromise = Utils.WithQueryPromise<Account | null, Account> & {
                 name: <T = Account | null>(name: Account["name"], options?: Record<string, unknown>) => Promise<T>;
                 email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
                 image: <T = Account | null>(image: Account["image"], options?: Record<string, unknown>) => Promise<T>;
@@ -341,12 +341,12 @@ declare namespace Syntax {
             type ToQueryPromise = any;
             type UsingQuery = ReducedFunction & (<T = Accounts>(value: CombinedInstructions["using"]) => T);
             type UsingQueryPromise = ReducedFunction & (<T = Accounts>(value: CombinedInstructions["using"]) => Promise<T>);
-            type WithQuery = Utils.WithQuery<Accounts> & {
+            type WithQuery = Utils.WithQuery<Accounts, Account> & {
                 name: <T = Accounts>(name: Account["name"], options?: Record<string, unknown>) => T;
                 email: <T = Accounts>(email: Account["email"], options?: Record<string, unknown>) => T;
                 image: <T = Accounts>(image: Account["image"], options?: Record<string, unknown>) => T;
             };
-            type WithQueryPromise = Utils.WithQueryPromise<Accounts> & {
+            type WithQueryPromise = Utils.WithQueryPromise<Accounts, Account> & {
                 name: <T = Accounts>(name: Account["name"], options?: Record<string, unknown>) => Promise<T>;
                 email: <T = Accounts>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
                 image: <T = Accounts>(image: Account["image"], options?: Record<string, unknown>) => Promise<T>;
@@ -508,8 +508,8 @@ declare namespace Utils {
     type RootQueryCallerPromise<U> = <T = U>(instructions?: Partial<CombinedInstructions>, options?: Record<string, unknown>) => Promise<T>;
     type SelectingQuery<U, F> = ReducedFunction & (<T = U>(instructions: Array<F>, options?: Record<string, unknown>) => T);
     type SelectingQueryPromise<U, F> = ReducedFunction & (<T = U>(instructions: Array<F>, options?: Record<string, unknown>) => Promise<T>);
-    type WithQuery<U> = ReducedFunction & {
-        <T = U>(instructions: CombinedInstructions["with"], options?: Record<string, unknown>): T;
+    type WithQuery<U, S> = ReducedFunction & {
+        <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): T;
         id: <T = U>(value: ResultRecord["id"], options?: Record<string, unknown>) => T;
         ronin: ReducedFunction & {
             createdAt: <T = U>(value: ResultRecord["ronin"]["createdAt"], options?: Record<string, unknown>) => T;
@@ -518,8 +518,8 @@ declare namespace Utils {
             updatedBy: <T = U>(value: ResultRecord["ronin"]["updatedBy"], options?: Record<string, unknown>) => T;
         };
     };
-    type WithQueryPromise<U> = ReducedFunction & {
-        <T = U>(instructions: CombinedInstructions["with"], options?: Record<string, unknown>): Promise<T>;
+    type WithQueryPromise<U, S> = ReducedFunction & {
+        <T = U>(instructions: Partial<S> | CombinedInstructions["with"], options?: Record<string, unknown>): Promise<T>;
         id: <T = U>(value: ResultRecord["id"], options?: Record<string, unknown>) => Promise<T>;
         ronin: ReducedFunction & {
             createdAt: <T = U>(value: ResultRecord["ronin"]["createdAt"], options?: Record<string, unknown>) => Promise<T>;

--- a/packages/blade-codegen/tests/generators/__snapshots__/namespaces.test.ts.snap
+++ b/packages/blade-codegen/tests/generators/__snapshots__/namespaces.test.ts.snap
@@ -22,7 +22,7 @@ exports[`namespaces with a basic model 1`] = `
         type ToQueryPromise = any;
         type UsingQuery = ReducedFunction & (<T = Account | null>(value: CombinedInstructions["using"]) => T);
         type UsingQueryPromise = ReducedFunction & (<T = Account | null>(value: CombinedInstructions["using"]) => Promise<T>);
-        type WithQuery = Utils.WithQuery<Account | null> & {
+        type WithQuery = Utils.WithQuery<Account | null, Account> & {
             avatar: <T = Account | null>(avatar: Account["avatar"], options?: Record<string, unknown>) => T;
             email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => T;
             isActive: <T = Account | null>(isActive: Account["isActive"], options?: Record<string, unknown>) => T;
@@ -31,7 +31,7 @@ exports[`namespaces with a basic model 1`] = `
             rewardPoints: <T = Account | null>(rewardPoints: Account["rewardPoints"], options?: Record<string, unknown>) => T;
             settings: <T = Account | null>(settings: Account["settings"], options?: Record<string, unknown>) => T;
         };
-        type WithQueryPromise = Utils.WithQueryPromise<Account | null> & {
+        type WithQueryPromise = Utils.WithQueryPromise<Account | null, Account> & {
             avatar: <T = Account | null>(avatar: Account["avatar"], options?: Record<string, unknown>) => Promise<T>;
             email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
             isActive: <T = Account | null>(isActive: Account["isActive"], options?: Record<string, unknown>) => Promise<T>;
@@ -60,7 +60,7 @@ exports[`namespaces with a basic model 1`] = `
         type ToQueryPromise = any;
         type UsingQuery = ReducedFunction & (<T = Accounts>(value: CombinedInstructions["using"]) => T);
         type UsingQueryPromise = ReducedFunction & (<T = Accounts>(value: CombinedInstructions["using"]) => Promise<T>);
-        type WithQuery = Utils.WithQuery<Accounts> & {
+        type WithQuery = Utils.WithQuery<Accounts, Account> & {
             avatar: <T = Accounts>(avatar: Account["avatar"], options?: Record<string, unknown>) => T;
             email: <T = Accounts>(email: Account["email"], options?: Record<string, unknown>) => T;
             isActive: <T = Accounts>(isActive: Account["isActive"], options?: Record<string, unknown>) => T;
@@ -69,7 +69,7 @@ exports[`namespaces with a basic model 1`] = `
             rewardPoints: <T = Accounts>(rewardPoints: Account["rewardPoints"], options?: Record<string, unknown>) => T;
             settings: <T = Accounts>(settings: Account["settings"], options?: Record<string, unknown>) => T;
         };
-        type WithQueryPromise = Utils.WithQueryPromise<Accounts> & {
+        type WithQueryPromise = Utils.WithQueryPromise<Accounts, Account> & {
             avatar: <T = Accounts>(avatar: Account["avatar"], options?: Record<string, unknown>) => Promise<T>;
             email: <T = Accounts>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
             isActive: <T = Accounts>(isActive: Account["isActive"], options?: Record<string, unknown>) => Promise<T>;
@@ -105,11 +105,11 @@ exports[`namespaces with a link field 1`] = `
         type ToQueryPromise = any;
         type UsingQuery = ReducedFunction & (<T = Account | null>(value: CombinedInstructions["using"]) => T);
         type UsingQueryPromise = ReducedFunction & (<T = Account | null>(value: CombinedInstructions["using"]) => Promise<T>);
-        type WithQuery = Utils.WithQuery<Account | null> & {
+        type WithQuery = Utils.WithQuery<Account | null, Account> & {
             name: <T = Account | null>(name: Account["name"], options?: Record<string, unknown>) => T;
             email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => T;
         };
-        type WithQueryPromise = Utils.WithQueryPromise<Account | null> & {
+        type WithQueryPromise = Utils.WithQueryPromise<Account | null, Account> & {
             name: <T = Account | null>(name: Account["name"], options?: Record<string, unknown>) => Promise<T>;
             email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
         };
@@ -133,11 +133,11 @@ exports[`namespaces with a link field 1`] = `
         type ToQueryPromise = any;
         type UsingQuery = ReducedFunction & (<T = Accounts>(value: CombinedInstructions["using"]) => T);
         type UsingQueryPromise = ReducedFunction & (<T = Accounts>(value: CombinedInstructions["using"]) => Promise<T>);
-        type WithQuery = Utils.WithQuery<Accounts> & {
+        type WithQuery = Utils.WithQuery<Accounts, Account> & {
             name: <T = Accounts>(name: Account["name"], options?: Record<string, unknown>) => T;
             email: <T = Accounts>(email: Account["email"], options?: Record<string, unknown>) => T;
         };
-        type WithQueryPromise = Utils.WithQueryPromise<Accounts> & {
+        type WithQueryPromise = Utils.WithQueryPromise<Accounts, Account> & {
             name: <T = Accounts>(name: Account["name"], options?: Record<string, unknown>) => Promise<T>;
             email: <T = Accounts>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
         };
@@ -170,13 +170,13 @@ namespace Post {
             <U extends Array<"author"> | "all">(fields: U): Promise<Post<U>> | null;
             <T = Post | null>(fields: Array<"author"> | "all"): Promise<T>;
         };
-        type WithQuery = Utils.WithQuery<Post | null> & {
+        type WithQuery = Utils.WithQuery<Post | null, Post> & {
             title: <T = Post | null>(title: Post["title"], options?: Record<string, unknown>) => T;
             author: <T = Post | null>(author: Post["author"] | Partial<Post<[
                 "author"
             ]>["author"]>, options?: Record<string, unknown>) => T;
         };
-        type WithQueryPromise = Utils.WithQueryPromise<Post | null> & {
+        type WithQueryPromise = Utils.WithQueryPromise<Post | null, Post> & {
             title: <T = Post | null>(title: Post["title"], options?: Record<string, unknown>) => Promise<T>;
             author: <T = Post | null>(author: Post["author"] | Partial<Post<[
                 "author"
@@ -208,13 +208,13 @@ namespace Post {
             <U extends Array<"author"> | "all">(fields: U): Promise<Post<U>>;
             <T = Posts>(fields: Array<"author"> | "all"): Promise<T>;
         };
-        type WithQuery = Utils.WithQuery<Posts> & {
+        type WithQuery = Utils.WithQuery<Posts, Post> & {
             title: <T = Posts>(title: Post["title"], options?: Record<string, unknown>) => T;
             author: <T = Posts>(author: Post["author"] | Partial<Post<[
                 "author"
             ]>["author"]>, options?: Record<string, unknown>) => T;
         };
-        type WithQueryPromise = Utils.WithQueryPromise<Posts> & {
+        type WithQueryPromise = Utils.WithQueryPromise<Posts, Post> & {
             title: <T = Posts>(title: Post["title"], options?: Record<string, unknown>) => Promise<T>;
             author: <T = Posts>(author: Post["author"] | Partial<Post<[
                 "author"

--- a/packages/blade-codegen/tests/generators/__snapshots__/syntax.test.ts.snap
+++ b/packages/blade-codegen/tests/generators/__snapshots__/syntax.test.ts.snap
@@ -53,7 +53,7 @@ exports[`syntax using plural asynchronous with a link field 1`] = `
 `;
 
 exports[`syntax with singular synchronous 1`] = `
-"type WithQuery = Utils.WithQuery<Account | null> & {
+"type WithQuery = Utils.WithQuery<Account | null, Account> & {
     name: <T = Account | null>(name: Account["name"], options?: Record<string, unknown>) => T;
     email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => T;
 };
@@ -61,7 +61,7 @@ exports[`syntax with singular synchronous 1`] = `
 `;
 
 exports[`syntax with singular asynchronous 1`] = `
-"type WithQueryPromise = Utils.WithQueryPromise<Account | null> & {
+"type WithQueryPromise = Utils.WithQueryPromise<Account | null, Account> & {
     name: <T = Account | null>(name: Account["name"], options?: Record<string, unknown>) => Promise<T>;
     email: <T = Account | null>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
 };
@@ -69,7 +69,7 @@ exports[`syntax with singular asynchronous 1`] = `
 `;
 
 exports[`syntax with plural synchronous 1`] = `
-"type WithQuery = Utils.WithQuery<Account[]> & {
+"type WithQuery = Utils.WithQuery<Account[], Account> & {
     name: <T = Account[]>(name: Account["name"], options?: Record<string, unknown>) => T;
     email: <T = Account[]>(email: Account["email"], options?: Record<string, unknown>) => T;
 };
@@ -77,7 +77,7 @@ exports[`syntax with plural synchronous 1`] = `
 `;
 
 exports[`syntax with plural asynchronous 1`] = `
-"type WithQueryPromise = Utils.WithQueryPromise<Account[]> & {
+"type WithQueryPromise = Utils.WithQueryPromise<Account[], Account> & {
     name: <T = Account[]>(name: Account["name"], options?: Record<string, unknown>) => Promise<T>;
     email: <T = Account[]>(email: Account["email"], options?: Record<string, unknown>) => Promise<T>;
 };


### PR DESCRIPTION
This change upgrades the code generation to improve the types used for queries such `.with(...)` queries. Now the properties or fields recommended are based on the singular schema. But we also retain the existing default combined instructions type, which allows for loose typing in order to support [advanced assertions](https://blade.im/queries/instructions#advanced-assertions).

<img width="772" height="370" alt="image" src="https://github.com/user-attachments/assets/3b74e633-befb-44fb-b2d2-9b4689de055a" />

In future I will improve this even more by making it so both:
 - The combined instructions fallback is not needed & instead advanced assertions are supported by default
 - Similarly nested link field properties are supported so you could have the following query be fully typed: `use.post.with({ author: { slug: '...' } })`
