### PR TITLE
Removed `flushSession` option from triggers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/blade": {
       "name": "blade",
-      "version": "3.17.6",
+      "version": "3.18.1",
       "bin": {
         "blade": "./dist/private/shell/index.js",
       },
@@ -66,7 +66,7 @@
     },
     "packages/blade-better-auth": {
       "name": "blade-better-auth",
-      "version": "3.17.6",
+      "version": "3.18.1",
       "dependencies": {
         "better-auth": "1.2.5",
       },
@@ -85,7 +85,7 @@
     },
     "packages/blade-cli": {
       "name": "blade-cli",
-      "version": "3.17.6",
+      "version": "3.18.1",
       "dependencies": {
         "@dprint/formatter": "0.4.1",
         "@dprint/typescript": "0.93.3",
@@ -115,7 +115,7 @@
     },
     "packages/blade-client": {
       "name": "blade-client",
-      "version": "3.17.6",
+      "version": "3.18.1",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -128,7 +128,7 @@
     },
     "packages/blade-codegen": {
       "name": "blade-codegen",
-      "version": "3.17.6",
+      "version": "3.18.1",
       "dependencies": {
         "typescript": "5.7.3",
       },
@@ -142,7 +142,7 @@
     },
     "packages/blade-compiler": {
       "name": "blade-compiler",
-      "version": "3.17.6",
+      "version": "3.18.1",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.14",
@@ -154,7 +154,7 @@
     },
     "packages/blade-syntax": {
       "name": "blade-syntax",
-      "version": "3.17.6",
+      "version": "3.18.1",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -166,7 +166,7 @@
     },
     "packages/create-blade": {
       "name": "create-blade",
-      "version": "3.17.6",
+      "version": "3.18.1",
       "bin": {
         "create-blade": "./dist/index.js",
       },

--- a/packages/blade/private/server/types/index.ts
+++ b/packages/blade/private/server/types/index.ts
@@ -97,14 +97,6 @@ export interface TriggerOptions extends ClientTriggerOptions {
    * triggers, by performing permission validation.
    */
   headless: boolean;
-  /**
-   * TODO: Remove this once we're no longer relying on it.
-   *
-   * Triggers a full page re-render and streams the updated UI to the client.
-   *
-   * Optionally it takes an array of queries to use for the next page render.
-   */
-  flushSession: NonNullable<ServerContext['flushSession']>;
 }
 
 export type RecursiveRequired<T> = {

--- a/packages/blade/private/server/utils/data.ts
+++ b/packages/blade/private/server/utils/data.ts
@@ -111,9 +111,6 @@ export const getClientConfig = (
       languages: serverContext.languages,
     },
     location: new URL(serverContext.url),
-
-    // TODO: Remove this once we're no longer relying on it.
-    flushSession: serverContext.flushSession,
   };
 
   const list = Object.entries(triggers || {}).map(
@@ -177,7 +174,7 @@ export const getClientConfig = (
   );
 
   const finalTriggers = Object.fromEntries(list);
-  const flush = options.flushSession;
+  const flush = serverContext.flushSession;
 
   let syntaxCallback: QueryHandlerOptions['syntaxCallback'];
 

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -408,7 +408,7 @@ export const flushSession = async (
     queries?: Array<QueryItemWrite>;
     repeat?: boolean;
   },
-): Promise<{ results?: Array<FormattedResults<ResultRecord>> }> => {
+): Promise<{ results?: FormattedResults<ResultRecord> }> => {
   // If the client is no longer connected, don't try to push an update. This therefore
   // also stops the interval of continuous revalidation.
   if (stream.aborted || stream.closed) return {};


### PR DESCRIPTION
Since https://github.com/ronin-co/blade/pull/493 has landed (check out the pull request for more details), the `flushSession` option that is currently being provided to triggers is no longer needed.