### PR TITLE
Prevent race condition during UI flushing

### DIFF
--- a/packages/blade/private/server/utils/index.ts
+++ b/packages/blade/private/server/utils/index.ts
@@ -21,6 +21,11 @@ export const generateHashSync = (input: string): number => {
 
 export class ResponseStream extends SSEStreamingApi {
   /**
+   * The time at which the last update started processing on the server (excludes
+   * revalidation). If the value is `null`, no update was processed yet.
+   */
+  lastStart: Date | null = null;
+  /**
    * The time at which the last update was sent by the server (excludes revalidation).
    * If the value is `null`, no update was sent yet.
    */

--- a/packages/blade/private/server/utils/index.ts
+++ b/packages/blade/private/server/utils/index.ts
@@ -24,12 +24,12 @@ export class ResponseStream extends SSEStreamingApi {
    * The time at which the last update started processing on the server (excludes
    * revalidation). If the value is `null`, no update was processed yet.
    */
-  lastStart: Date | null = null;
+  lastStart: number | null = null;
   /**
    * The time at which the last update was sent by the server (excludes revalidation).
    * If the value is `null`, no update was sent yet.
    */
-  lastEnd: Date | null = null;
+  lastEnd: number | null = null;
   /** The first request object provided by the client. */
   request: Request;
   /** The first response object returned to the client. */

--- a/packages/blade/private/server/utils/index.ts
+++ b/packages/blade/private/server/utils/index.ts
@@ -21,8 +21,8 @@ export const generateHashSync = (input: string): number => {
 
 export class ResponseStream extends SSEStreamingApi {
   /**
-   * The time at which the last flush was started processing. If the value is `null`,
-   * no update was processed yet.
+   * The time at which the last update started processing. If the value is `null`, no
+   * update started processing yet.
    */
   lastStart: number | null = null;
   /** The first request object provided by the client. */

--- a/packages/blade/private/server/utils/index.ts
+++ b/packages/blade/private/server/utils/index.ts
@@ -24,7 +24,7 @@ export class ResponseStream extends SSEStreamingApi {
    * The time at which the last update started processing. If the value is `null`, no
    * update started processing yet.
    */
-  lastStart: number | null = null;
+  lastUpdate: number | null = null;
   /** The first request object provided by the client. */
   request: Request;
   /** The first response object returned to the client. */

--- a/packages/blade/private/server/utils/index.ts
+++ b/packages/blade/private/server/utils/index.ts
@@ -24,7 +24,7 @@ export class ResponseStream extends SSEStreamingApi {
    * The time at which the last update was sent by the server (excludes revalidation).
    * If the value is `null`, no update was sent yet.
    */
-  lastUpdate: Date | null = null;
+  lastEnd: Date | null = null;
   /** The first request object provided by the client. */
   request: Request;
   /** The first response object returned to the client. */

--- a/packages/blade/private/server/utils/index.ts
+++ b/packages/blade/private/server/utils/index.ts
@@ -21,15 +21,10 @@ export const generateHashSync = (input: string): number => {
 
 export class ResponseStream extends SSEStreamingApi {
   /**
-   * The time at which the last update started processing on the server (excludes
-   * revalidation). If the value is `null`, no update was processed yet.
+   * The time at which the last flush was started processing. If the value is `null`,
+   * no update was processed yet.
    */
   lastStart: number | null = null;
-  /**
-   * The time at which the last update was sent by the server (excludes revalidation).
-   * If the value is `null`, no update was sent yet.
-   */
-  lastEnd: number | null = null;
   /** The first request object provided by the client. */
   request: Request;
   /** The first response object returned to the client. */

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -443,7 +443,6 @@ export const flushSession = async (
     // If another flush happened since the last revalidation, we can skip the current
     // revalidation and wait for the next one, to avoid unnecessary pushes.
     if (options?.repeat && recentFlush) {
-      console.log('SKIPPED FLUSH');
       // The `finally` block will still execute before this.
       return {};
     }

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -440,7 +440,7 @@ export const flushSession = async (
       stream.lastUpdate !== null &&
       stream.lastUpdate > performance.now() - REVALIDATION_INTERVAL;
 
-    // If another flush was started since the last revalidation, we can skip the current
+    // If another flush happened since the last revalidation, we can skip the current
     // revalidation and wait for the next one, to avoid unnecessary pushes.
     if (options?.repeat && recentFlush) {
       console.log('SKIPPED FLUSH');

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -418,6 +418,9 @@ export const flushSession = async (
   // also stops the interval of continuous revalidation.
   if (stream.aborted || stream.closed) return {};
 
+  // Track the start time of the current manual update.
+  if (options?.queries) stream.lastStart = new Date();
+
   const nestedFlushSession: ServerContext['flushSession'] = async (nestedQueries) => {
     const newOptions: Parameters<typeof flushSession>[2] = {
       queries: nestedQueries
@@ -466,7 +469,7 @@ export const flushSession = async (
         : undefined,
     );
 
-    // Track the time of the current manual update.
+    // Track the end time of the current manual update.
     if (options?.queries) stream.lastEnd = new Date();
 
     // Afterward, flush the update over the stream.

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -479,11 +479,11 @@ export const flushSession = async (
       stream.lastUpdate !== null &&
       (stream.lastUpdate > currentStart || stream.lastUpdate === currentStart);
 
-    // Track the start time of the current update.
-    stream.lastUpdate = currentStart;
-
-    // Afterward, flush the update over the stream.
     if (!superseded) {
+      // Track the start time of the current update.
+      stream.lastUpdate = currentStart;
+
+      // Afterward, flush the update over the stream.
       await stream.writeChunk(correctBundle ? 'update' : 'update-bundle', response);
     }
 

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -436,12 +436,13 @@ export const flushSession = async (
   };
 
   try {
-    const recentManualFlush =
-      (stream.lastEnd === null ? 0 : stream.lastEnd) > Date.now() - REVALIDATION_INTERVAL;
+    const recentFlush =
+      (stream.lastStart === null ? 0 : stream.lastStart) >
+      Date.now() - REVALIDATION_INTERVAL;
 
-    // If a manual update was sent since the last revalidation, we can skip the current
+    // If another flush was started since the last revalidation, we can skip the current
     // revalidation and wait for the next one, to avoid unnecessary pushes.
-    if (options?.repeat && recentManualFlush) {
+    if (options?.repeat && recentFlush) {
       // The `finally` block will still execute before this.
       return {};
     }
@@ -468,9 +469,6 @@ export const flushSession = async (
           }
         : undefined,
     );
-
-    // Track the end time of the current manual update.
-    if (options?.queries) stream.lastEnd = performance.now();
 
     // This will be `true` if a different flush finished while the current one was still
     // ongoing, which ensures that the UI never gets reverted back to something old.

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -471,7 +471,7 @@ export const flushSession = async (
     );
 
     // This will be `true` if a different flush finished while the current one was still
-    // ongoing, which ensures that the UI never gets reverted back to something old.
+    // ongoing, which allows us to prevent the UI from getting reverted to an old state.
     //
     // It is essential to perform this check, since the page rendering performs `await`ed
     // actions, which might take a different time to run every time.

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -437,12 +437,13 @@ export const flushSession = async (
 
   try {
     const recentFlush =
-      (stream.lastUpdate === null ? 0 : stream.lastUpdate) >
-      Date.now() - REVALIDATION_INTERVAL;
+      stream.lastUpdate !== null &&
+      stream.lastUpdate > performance.now() - REVALIDATION_INTERVAL;
 
     // If another flush was started since the last revalidation, we can skip the current
     // revalidation and wait for the next one, to avoid unnecessary pushes.
     if (options?.repeat && recentFlush) {
+      console.log('SKIPPED FLUSH');
       // The `finally` block will still execute before this.
       return {};
     }

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -419,7 +419,7 @@ export const flushSession = async (
   if (stream.aborted || stream.closed) return {};
 
   // Track the start time of the current manual update.
-  if (options?.queries) stream.lastStart = new Date();
+  if (options?.queries) stream.lastStart = performance.now();
 
   const nestedFlushSession: ServerContext['flushSession'] = async (nestedQueries) => {
     const newOptions: Parameters<typeof flushSession>[2] = {
@@ -437,7 +437,7 @@ export const flushSession = async (
 
   try {
     const recentManualFlush =
-      (stream.lastEnd?.getTime() || 0) > Date.now() - REVALIDATION_INTERVAL;
+      (stream.lastEnd === null ? 0 : stream.lastEnd) > Date.now() - REVALIDATION_INTERVAL;
 
     // If a manual update was sent since the last revalidation, we can skip the current
     // revalidation and wait for the next one, to avoid unnecessary pushes.
@@ -470,7 +470,7 @@ export const flushSession = async (
     );
 
     // Track the end time of the current manual update.
-    if (options?.queries) stream.lastEnd = new Date();
+    if (options?.queries) stream.lastEnd = performance.now();
 
     // Afterward, flush the update over the stream.
     await stream.writeChunk(correctBundle ? 'update' : 'update-bundle', response);

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -477,7 +477,9 @@ export const flushSession = async (
     //
     // It is essential to perform this check, since the page rendering performs `await`ed
     // actions, which might take a different time to run every time.
-    const superseded = stream.lastStart !== null && stream.lastStart > currentStart;
+    const superseded =
+      stream.lastStart !== null &&
+      (stream.lastStart > currentStart || stream.lastStart === currentStart);
 
     // Track the start time of the current update.
     stream.lastStart = currentStart;

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -437,7 +437,7 @@ export const flushSession = async (
 
   try {
     const recentFlush =
-      (stream.lastStart === null ? 0 : stream.lastStart) >
+      (stream.lastUpdate === null ? 0 : stream.lastUpdate) >
       Date.now() - REVALIDATION_INTERVAL;
 
     // If another flush was started since the last revalidation, we can skip the current
@@ -476,11 +476,11 @@ export const flushSession = async (
     // It is essential to perform this check, since the page rendering performs `await`ed
     // actions, which might take a different time to run every time.
     const superseded =
-      stream.lastStart !== null &&
-      (stream.lastStart > currentStart || stream.lastStart === currentStart);
+      stream.lastUpdate !== null &&
+      (stream.lastUpdate > currentStart || stream.lastUpdate === currentStart);
 
     // Track the start time of the current update.
-    stream.lastStart = currentStart;
+    stream.lastUpdate = currentStart;
 
     // Afterward, flush the update over the stream.
     if (!superseded) {

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -434,7 +434,7 @@ export const flushSession = async (
 
   try {
     const recentManualFlush =
-      (stream.lastUpdate?.getTime() || 0) > Date.now() - REVALIDATION_INTERVAL;
+      (stream.lastEnd?.getTime() || 0) > Date.now() - REVALIDATION_INTERVAL;
 
     // If a manual update was sent since the last revalidation, we can skip the current
     // revalidation and wait for the next one, to avoid unnecessary pushes.
@@ -467,7 +467,7 @@ export const flushSession = async (
     );
 
     // Track the time of the current manual update.
-    if (options?.queries) stream.lastUpdate = new Date();
+    if (options?.queries) stream.lastEnd = new Date();
 
     // Afterward, flush the update over the stream.
     await stream.writeChunk(correctBundle ? 'update' : 'update-bundle', response);


### PR DESCRIPTION
When flushing many UI updates, older updates might take longer to process than newer ones, which would cause the UI to temporarily get reverted back to an old state.

The change right here ensures that we track the time of the last update, so that only newer updates are ever applied.

This is better than queueing the flushes, since it ensures maximum speed and "the fastest wins", while still ensuring UI consistency. Queueing the flushes would be slow.