### PR TITLE
Ensure correct client-side error names

### DIFF
--- a/packages/blade-client/src/triggers/errors.ts
+++ b/packages/blade-client/src/triggers/errors.ts
@@ -1,4 +1,5 @@
 interface ErrorDetails {
+  name?: string;
   message?: string;
   code?: string;
   fields?: string[];
@@ -25,7 +26,7 @@ class TriggerError extends Error {
   constructor(details?: ErrorDetails) {
     super(details?.message);
 
-    this.name = 'TriggerError';
+    this.name = details?.name || 'TriggerError';
     this.code = details?.code;
     this.fields = details?.fields || [];
     this.instructions = details?.instructions || [];
@@ -38,6 +39,7 @@ class InvalidFieldsError extends TriggerError {
     const joined = joinFields(fields);
 
     super({
+      name: 'InvalidFieldsError',
       message:
         details?.message ||
         reasons?.join(' | ') ||
@@ -54,6 +56,7 @@ class EmptyFieldsError extends TriggerError {
     const joined = joinFields(fields);
 
     super({
+      name: 'EmptyFieldsError',
       message:
         details?.message ||
         `Empty fields provided${fields?.length > 0 ? `: ${joined}` : ''}.`,
@@ -69,6 +72,7 @@ class ExtraneousFieldsError extends TriggerError {
     const joined = joinFields(fields);
 
     super({
+      name: 'ExtraneousFieldsError',
       message:
         details?.message ||
         `Extraneous fields provided${fields?.length > 0 ? `: ${joined}` : ''}.`,
@@ -81,6 +85,7 @@ class ExtraneousFieldsError extends TriggerError {
 class RecordExistsError extends TriggerError {
   constructor(details?: ErrorDetails) {
     super({
+      name: 'RecordExistsError',
       message: details?.message || 'The provided record already exists.',
       code: details?.code || 'RECORD_EXISTS',
       fields: details?.fields,
@@ -91,6 +96,7 @@ class RecordExistsError extends TriggerError {
 class RecordNotFoundError extends TriggerError {
   constructor(details?: ErrorDetails) {
     super({
+      name: 'RecordNotFoundError',
       message: details?.message || 'No record could be found for the provided query.',
       code: details?.code || 'RECORD_NOT_FOUND',
       fields: details?.fields,
@@ -101,6 +107,7 @@ class RecordNotFoundError extends TriggerError {
 class TooManyRequestsError extends TriggerError {
   constructor(details?: ErrorDetails) {
     super({
+      name: 'TooManyRequestsError',
       message:
         details?.message ||
         'The specified schema is being queried too quickly. Please try again later.',
@@ -113,6 +120,7 @@ class TooManyRequestsError extends TriggerError {
 class InvalidPermissionsError extends TriggerError {
   constructor(details?: ErrorDetails) {
     super({
+      name: 'InvalidPermissionsError',
       message: details?.message || 'You do not have permission to perform this action.',
       code: details?.code || 'INVALID_PERMISSIONS',
     });
@@ -122,6 +130,7 @@ class InvalidPermissionsError extends TriggerError {
 class MultipleWithInstructionsError extends TriggerError {
   constructor() {
     super({
+      name: 'MultipleWithInstructionsError',
       message: 'The given `with` instruction must not be an array.',
       code: 'INVALID_QUERY_INSTRUCTIONS',
       instructions: ['with'],


### PR DESCRIPTION
This change ensures that trigger errors that are sent to the client correctly retain their `name`.