### PR TITLE
Optionally limit writes to 1 DB connection

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,6 @@
         "gradient-string": "3.0.0",
         "resolve-from": "5.0.0",
         "rolldown": "1.0.0-beta.32",
-        "undici": "7.16.0",
       },
       "devDependencies": {
         "@hono/node-server": "1.14.4",
@@ -117,9 +116,6 @@
     "packages/blade-client": {
       "name": "blade-client",
       "version": "3.18.13",
-      "dependencies": {
-        "undici": "7.16.0",
-      },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -1138,8 +1134,6 @@
     "unconfig": ["unconfig@7.3.3", "", { "dependencies": { "@quansync/fs": "^0.1.5", "defu": "^6.1.4", "jiti": "^2.5.1", "quansync": "^0.2.11" } }, "sha512-QCkQoOnJF8L107gxfHL0uavn7WD9b3dpBcFX6HtfQYmjw2YzWxGuFQ0N0J6tE9oguCBJn9KOvfqYDCMPHIZrBA=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
-
-    "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
     "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -75,7 +75,7 @@
         "@types/bun": "1.2.8",
         "blade-client": "workspace:*",
         "blade-compiler": "workspace:*",
-        "hive": "2.1.0",
+        "hive": "2.1.2",
         "tsdown": "0.15.2",
         "typescript": "5.8.2",
       },
@@ -108,7 +108,7 @@
         "blade-compiler": "workspace:*",
         "blade-syntax": "workspace:*",
         "bun-bagel": "1.1.0",
-        "hive": "2.1.0",
+        "hive": "2.1.2",
         "tsdown": "0.15.2",
         "typescript": "5.8.3",
       },
@@ -121,7 +121,7 @@
         "@types/bun": "1.2.4",
         "blade-compiler": "workspace:*",
         "blade-syntax": "workspace:*",
-        "hive": "2.1.0",
+        "hive": "2.1.2",
         "tsdown": "0.15.2",
         "typescript": "5.8.3",
       },
@@ -146,7 +146,7 @@
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.14",
-        "hive": "2.1.0",
+        "hive": "2.1.2",
         "title": "4.0.1",
         "tsdown": "0.15.2",
         "typescript": "5.7.2",
@@ -757,7 +757,7 @@
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
-    "hive": ["hive@2.1.0", "", { "dependencies": { "hono": "4.9.7", "zod": "4.1.8" }, "peerDependencies": { "@types/bun": "latest", "drizzle-orm": "0.44.5", "typescript": "5.9.2" } }, "sha512-Ai9MaiPAxOjx1cpXFjspP66wrLfaUnR3uecQQ5q6su+LKsQ6n/E4lFPPpZsKHVQb+9pYFQ8QE0XxCqzmeRiWHA=="],
+    "hive": ["hive@2.1.2", "", { "dependencies": { "hono": "4.9.7", "zod": "4.1.8" }, "peerDependencies": { "@types/bun": "latest", "drizzle-orm": "0.44.5", "typescript": "5.9.2" } }, "sha512-XUoeoyjMNs60ueTdWT2OPR6bn3IBEMvmgvTBYxRCdGsBIyizokochPD5zVYzhd2p2Wv/pRH6jr/9nU4YMukRyw=="],
 
     "hono": ["hono@4.7.11", "", {}, "sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -124,6 +124,7 @@
         "hive": "2.1.2",
         "tsdown": "0.15.2",
         "typescript": "5.8.3",
+        "undici": "7.16.0",
       },
     },
     "packages/blade-codegen": {
@@ -1134,6 +1135,8 @@
     "unconfig": ["unconfig@7.3.3", "", { "dependencies": { "@quansync/fs": "^0.1.5", "defu": "^6.1.4", "jiti": "^2.5.1", "quansync": "^0.2.11" } }, "sha512-QCkQoOnJF8L107gxfHL0uavn7WD9b3dpBcFX6HtfQYmjw2YzWxGuFQ0N0J6tE9oguCBJn9KOvfqYDCMPHIZrBA=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici": ["undici@7.16.0", "", {}, "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g=="],
 
     "undici-types": ["undici-types@7.8.0", "", {}, "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "gradient-string": "3.0.0",
         "resolve-from": "5.0.0",
         "rolldown": "1.0.0-beta.32",
+        "undici": "7.16.0",
       },
       "devDependencies": {
         "@hono/node-server": "1.14.4",
@@ -116,6 +117,9 @@
     "packages/blade-client": {
       "name": "blade-client",
       "version": "3.18.13",
+      "dependencies": {
+        "undici": "7.16.0",
+      },
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -124,7 +128,6 @@
         "hive": "2.1.2",
         "tsdown": "0.15.2",
         "typescript": "5.8.3",
-        "undici": "7.16.0",
       },
     },
     "packages/blade-codegen": {

--- a/packages/blade-better-auth/package.json
+++ b/packages/blade-better-auth/package.json
@@ -42,7 +42,7 @@
     "@types/bun": "1.2.8",
     "blade-client": "workspace:*",
     "blade-compiler": "workspace:*",
-    "hive": "2.1.0",
+    "hive": "2.1.2",
     "tsdown": "0.15.2",
     "typescript": "5.8.2"
   },

--- a/packages/blade-cli/package.json
+++ b/packages/blade-cli/package.json
@@ -87,7 +87,7 @@
     "blade-compiler": "workspace:*",
     "blade-syntax": "workspace:*",
     "bun-bagel": "1.1.0",
-    "hive": "2.1.0",
+    "hive": "2.1.2",
     "tsdown": "0.15.2",
     "typescript": "5.8.3"
   }

--- a/packages/blade-cli/tsdown.config.ts
+++ b/packages/blade-cli/tsdown.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
     'commands/types': './src/commands/types.ts',
     flags: './src/flags.ts',
   },
-  external: ['typescript'],
+  external: ['typescript', 'undici'],
   format: 'esm',
 });

--- a/packages/blade-client/package.json
+++ b/packages/blade-client/package.json
@@ -68,8 +68,5 @@
     "hive": "2.1.2",
     "tsdown": "0.15.2",
     "typescript": "5.8.3"
-  },
-  "dependencies": {
-    "undici": "7.16.0"
   }
 }

--- a/packages/blade-client/package.json
+++ b/packages/blade-client/package.json
@@ -65,7 +65,7 @@
     "@types/bun": "1.2.4",
     "blade-compiler": "workspace:*",
     "blade-syntax": "workspace:*",
-    "hive": "2.1.0",
+    "hive": "2.1.2",
     "tsdown": "0.15.2",
     "typescript": "5.8.3"
   }

--- a/packages/blade-client/package.json
+++ b/packages/blade-client/package.json
@@ -67,7 +67,9 @@
     "blade-syntax": "workspace:*",
     "hive": "2.1.2",
     "tsdown": "0.15.2",
-    "typescript": "5.8.3",
+    "typescript": "5.8.3"
+  },
+  "dependencies": {
     "undici": "7.16.0"
   }
 }

--- a/packages/blade-client/package.json
+++ b/packages/blade-client/package.json
@@ -67,6 +67,7 @@
     "blade-syntax": "workspace:*",
     "hive": "2.1.2",
     "tsdown": "0.15.2",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "undici": "7.16.0"
   }
 }

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -40,10 +40,6 @@ export interface ResultPerDatabase<T> {
 
 const clients: Record<string, Hive> = {};
 
-const parseResource = (list: string): Record<string, string> => {
-  return Object.fromEntries(list.split('/').map((p) => p.split(':')));
-};
-
 const defaultDatabaseCaller: QueryHandlerOptions['databaseCaller'] = async (
   statements,
   options,
@@ -62,10 +58,8 @@ const defaultDatabaseCaller: QueryHandlerOptions['databaseCaller'] = async (
     });
   }
 
-  const hive = clients[token];
-  const resource = parseResource(database);
-  const namespace = new Selector({ type: 'namespace', id: resource.ns });
-  const db = new Selector({ type: 'database', id: resource.db, parent: namespace });
+  const hive = clients[key];
+  const db = new Selector<'database'>(database);
 
   const results = await hive.storage.query(db, {
     statements: statements.map((item) => ({ ...item, method: 'values' })),

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -28,7 +28,13 @@ import { formatDateFields, validateDefaults } from '@/src/utils/helpers';
 let Agent: typeof AgentClass | undefined;
 
 // Skip it on workers for now.
-if (typeof process !== 'undefined') ({ Agent } = await import('undici'));
+if (typeof process !== 'undefined') {
+  try {
+    ({ Agent } = await import('undici'));
+  } catch (_err) {
+    // It's fine if the package is not installed.
+  }
+}
 
 export interface QueryPerDatabase {
   query: Query;

--- a/packages/blade-client/src/types/utils.ts
+++ b/packages/blade-client/src/types/utils.ts
@@ -43,7 +43,7 @@ export interface QueryHandlerOptions {
    */
   databaseCaller?: (
     statements: Array<Statement>,
-    options: { token: string; database: string },
+    options: { token: string; database: string; writing: boolean },
   ) => Promise<DatabaseResult> | DatabaseResult;
 
   /**

--- a/packages/blade-client/tests/integration/factory.test.ts
+++ b/packages/blade-client/tests/integration/factory.test.ts
@@ -26,7 +26,7 @@ describe('factory', () => {
           returning: true,
         },
       ],
-      { token: 'takashitoken', database: 'takashidatabase' },
+      { token: 'takashitoken', database: 'takashidatabase', writing: false },
     );
   });
 

--- a/packages/blade-client/tsdown.config.ts
+++ b/packages/blade-client/tsdown.config.ts
@@ -9,5 +9,5 @@ export default defineConfig({
     'src/schema/index.ts',
     'src/utils/index.ts',
   ],
-  format: 'esm'
+  format: 'esm',
 });

--- a/packages/blade-client/tsdown.config.ts
+++ b/packages/blade-client/tsdown.config.ts
@@ -10,4 +10,5 @@ export default defineConfig({
     'src/utils/index.ts',
   ],
   format: 'esm',
+  external: ['undici'],
 });

--- a/packages/blade-client/tsdown.config.ts
+++ b/packages/blade-client/tsdown.config.ts
@@ -9,5 +9,5 @@ export default defineConfig({
     'src/schema/index.ts',
     'src/utils/index.ts',
   ],
-  format: 'esm',
+  format: 'esm'
 });

--- a/packages/blade-compiler/package.json
+++ b/packages/blade-compiler/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/bun": "1.1.14",
-    "hive": "2.1.0",
+    "hive": "2.1.2",
     "title": "4.0.1",
     "tsdown": "0.15.2",
     "typescript": "5.7.2"

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -61,7 +61,8 @@
     "dotenv": "16.5.0",
     "gradient-string": "3.0.0",
     "resolve-from": "5.0.0",
-    "rolldown": "1.0.0-beta.32"
+    "rolldown": "1.0.0-beta.32",
+    "undici": "7.16.0"
   },
   "devDependencies": {
     "@hono/node-server": "1.14.4",

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -61,8 +61,7 @@
     "dotenv": "16.5.0",
     "gradient-string": "3.0.0",
     "resolve-from": "5.0.0",
-    "rolldown": "1.0.0-beta.32",
-    "undici": "7.16.0"
+    "rolldown": "1.0.0-beta.32"
   },
   "devDependencies": {
     "@hono/node-server": "1.14.4",

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -122,7 +122,7 @@ export const composeBuildContext = async (
       },
     },
 
-    external: [...(packageMetaContent?.blade?.external || []), 'undici'],
+    external: packageMetaContent?.blade?.external,
 
     plugins: [
       getFileListLoader(options?.virtualFiles),

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -122,7 +122,7 @@ export const composeBuildContext = async (
       },
     },
 
-    external: packageMetaContent?.blade?.external,
+    external: [...(packageMetaContent?.blade?.external || []), 'undici'],
 
     plugins: [
       getFileListLoader(options?.virtualFiles),

--- a/packages/blade/tsdown.config.ts
+++ b/packages/blade/tsdown.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     'react-dom/client',
     'react-dom/server.browser',
     'typescript',
+    'undici',
   ],
   treeshake: true,
   define: {


### PR DESCRIPTION
This change temporarily ensures that only one connection is maintained for all writes per Blade instance.

However, this behavior is only enabled if the `undici` package is installed.