### PR TITLE
Ensure use of latest version of `rollup-plugin-dts`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -183,7 +183,7 @@
     },
   },
   "overrides": {
-    "rolldown-plugin-dts": "^0.16.8",
+    "rollup-plugin-dts": "^0.16.8",
   },
   "packages": {
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "turbo": "2.5.6"
   },
   "overrides": {
-    "rolldown-plugin-dts": "^0.16.8"
+    "rollup-plugin-dts": "^0.16.8"
   }
 }


### PR DESCRIPTION
This PR adds an override to make sure that the latest version of `rollup-plugin-dts` is installed.

Recently the package released version `0.16.7` which breaks our CI builds & since only a forward fix has been applied and the broken version has not been yanked, the broken version can still occasionally be installed, such as when bumping out lockfile after publishing a new version, and thus breaking out CI. This change **_should_** fix that by making sure that only `0.16.8` is installed & this patch can be removed at a later date.