### PR TITLE
Auto-disable HTTP/2 multiplexing if needed

### DIFF
--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -53,7 +53,9 @@ export interface ResultPerDatabase<T> {
 
 const clients: Record<string, Hive> = {};
 
-const dispatcher = Agent ? new Agent({ connections: 1 }) : undefined;
+const dispatcher = Agent
+  ? new Agent({ connections: 1, allowH2: false, pipelining: 1 })
+  : undefined;
 
 const fetchWithDispatcher: typeof fetch = (input, init) =>
   input instanceof Request


### PR DESCRIPTION
If https://github.com/ronin-co/blade/pull/513 is triggered by adding `undici`, the current change will ensure that writes aren't multiplexed on the same HTTP/2 connection. Instead, they will arrive in order.