### PR TITLE
Support HTTP/2 for writes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/blade": {
       "name": "blade",
-      "version": "3.18.14",
+      "version": "3.18.15",
       "bin": {
         "blade": "./dist/private/shell/index.js",
       },
@@ -66,7 +66,7 @@
     },
     "packages/blade-better-auth": {
       "name": "blade-better-auth",
-      "version": "3.18.14",
+      "version": "3.18.15",
       "dependencies": {
         "better-auth": "1.2.5",
       },
@@ -85,7 +85,7 @@
     },
     "packages/blade-cli": {
       "name": "blade-cli",
-      "version": "3.18.14",
+      "version": "3.18.15",
       "dependencies": {
         "@dprint/formatter": "0.4.1",
         "@dprint/typescript": "0.93.3",
@@ -115,7 +115,7 @@
     },
     "packages/blade-client": {
       "name": "blade-client",
-      "version": "3.18.14",
+      "version": "3.18.15",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -128,7 +128,7 @@
     },
     "packages/blade-codegen": {
       "name": "blade-codegen",
-      "version": "3.18.14",
+      "version": "3.18.15",
       "dependencies": {
         "typescript": "5.7.3",
       },
@@ -142,7 +142,7 @@
     },
     "packages/blade-compiler": {
       "name": "blade-compiler",
-      "version": "3.18.14",
+      "version": "3.18.15",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.14",
@@ -154,7 +154,7 @@
     },
     "packages/blade-syntax": {
       "name": "blade-syntax",
-      "version": "3.18.14",
+      "version": "3.18.15",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -166,7 +166,7 @@
     },
     "packages/create-blade": {
       "name": "create-blade",
-      "version": "3.18.14",
+      "version": "3.18.15",
       "bin": {
         "create-blade": "./dist/index.js",
       },

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -57,10 +57,9 @@ const dispatcher = Agent
   ? new Agent({ connections: 1, maxConcurrentStreams: 1, pipelining: 1 })
   : undefined;
 
-const fetchWithDispatcher: typeof fetch = (input, init) =>
-  input instanceof Request
-    ? fetch(new Request(input, { dispatcher, ...init }))
-    : fetch(input, { dispatcher, ...init });
+const fetchWithDispatcher: typeof fetch = (input, init) => {
+  return fetch(input, { dispatcher, ...init });
+};
 
 const defaultDatabaseCaller: QueryHandlerOptions['databaseCaller'] = async (
   statements,
@@ -70,7 +69,7 @@ const defaultDatabaseCaller: QueryHandlerOptions['databaseCaller'] = async (
   const key = `${token}-${writing}`;
 
   if (!clients[key]) {
-    const prefix = writing ? 'db' : 'db-leader';
+    const prefix = writing ? 'db-leader' : 'db';
 
     clients[key] = new Hive({
       storage: new RemoteStorage({

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -58,7 +58,7 @@ const dispatcher = Agent
   : undefined;
 
 const fetchWithDispatcher: typeof fetch = (input, init) => {
-  return fetch(input, { dispatcher, ...init });
+  return fetch(input, { ...init, dispatcher });
 };
 
 const defaultDatabaseCaller: QueryHandlerOptions['databaseCaller'] = async (

--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -54,7 +54,7 @@ export interface ResultPerDatabase<T> {
 const clients: Record<string, Hive> = {};
 
 const dispatcher = Agent
-  ? new Agent({ connections: 1, allowH2: false, pipelining: 1 })
+  ? new Agent({ connections: 1, maxConcurrentStreams: 1, pipelining: 1 })
   : undefined;
 
 const fetchWithDispatcher: typeof fetch = (input, init) =>

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -470,6 +470,9 @@ export const flushSession = async (
         : undefined,
     );
 
+    // Track the start time of the current update.
+    stream.lastUpdate = currentStart;
+
     await stream.writeChunk(correctBundle ? 'update' : 'update-bundle', response);
 
     // The `finally` block will still execute before this.

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -470,22 +470,7 @@ export const flushSession = async (
         : undefined,
     );
 
-    // This will be `true` if a different flush finished while the current one was still
-    // ongoing, which allows us to prevent the UI from getting reverted to an old state.
-    //
-    // It is essential to perform this check, since the page rendering performs `await`ed
-    // actions, which might take a different time to run every time.
-    const superseded =
-      stream.lastUpdate !== null &&
-      (stream.lastUpdate > currentStart || stream.lastUpdate === currentStart);
-
-    if (!superseded) {
-      // Track the start time of the current update.
-      stream.lastUpdate = currentStart;
-
-      // Afterward, flush the update over the stream.
-      await stream.writeChunk(correctBundle ? 'update' : 'update-bundle', response);
-    }
+    await stream.writeChunk(correctBundle ? 'update' : 'update-bundle', response);
 
     // The `finally` block will still execute before this.
     return { results: writeResults };


### PR DESCRIPTION
This change ensures that HTTP/2 is retained for writes, but multiplex streams are disabled to ensure order for writes.