### PR TITLE
Bump `hive` to `2.1.4`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/blade": {
       "name": "blade",
-      "version": "3.18.17",
+      "version": "3.18.18",
       "bin": {
         "blade": "./dist/private/shell/index.js",
       },
@@ -66,7 +66,7 @@
     },
     "packages/blade-better-auth": {
       "name": "blade-better-auth",
-      "version": "3.18.17",
+      "version": "3.18.18",
       "dependencies": {
         "better-auth": "1.2.5",
       },
@@ -75,7 +75,7 @@
         "@types/bun": "1.2.8",
         "blade-client": "workspace:*",
         "blade-compiler": "workspace:*",
-        "hive": "2.1.3",
+        "hive": "2.1.4",
         "tsdown": "0.15.2",
         "typescript": "5.8.2",
       },
@@ -85,7 +85,7 @@
     },
     "packages/blade-cli": {
       "name": "blade-cli",
-      "version": "3.18.17",
+      "version": "3.18.18",
       "dependencies": {
         "@dprint/formatter": "0.4.1",
         "@dprint/typescript": "0.93.3",
@@ -108,27 +108,27 @@
         "blade-compiler": "workspace:*",
         "blade-syntax": "workspace:*",
         "bun-bagel": "1.1.0",
-        "hive": "2.1.3",
+        "hive": "2.1.4",
         "tsdown": "0.15.2",
         "typescript": "5.8.3",
       },
     },
     "packages/blade-client": {
       "name": "blade-client",
-      "version": "3.18.17",
+      "version": "3.18.18",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
         "blade-compiler": "workspace:*",
         "blade-syntax": "workspace:*",
-        "hive": "2.1.3",
+        "hive": "2.1.4",
         "tsdown": "0.15.2",
         "typescript": "5.8.3",
       },
     },
     "packages/blade-codegen": {
       "name": "blade-codegen",
-      "version": "3.18.17",
+      "version": "3.18.18",
       "dependencies": {
         "typescript": "5.7.3",
       },
@@ -142,11 +142,11 @@
     },
     "packages/blade-compiler": {
       "name": "blade-compiler",
-      "version": "3.18.17",
+      "version": "3.18.18",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.14",
-        "hive": "2.1.3",
+        "hive": "2.1.4",
         "title": "4.0.1",
         "tsdown": "0.15.2",
         "typescript": "5.7.2",
@@ -154,7 +154,7 @@
     },
     "packages/blade-syntax": {
       "name": "blade-syntax",
-      "version": "3.18.17",
+      "version": "3.18.18",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -166,7 +166,7 @@
     },
     "packages/create-blade": {
       "name": "create-blade",
-      "version": "3.18.17",
+      "version": "3.18.18",
       "bin": {
         "create-blade": "./dist/index.js",
       },
@@ -760,7 +760,7 @@
 
     "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
-    "hive": ["hive@2.1.3", "", { "dependencies": { "hono": "4.9.7", "zod": "4.1.8" }, "peerDependencies": { "@types/bun": "latest", "drizzle-orm": "0.44.5", "typescript": "5.9.2" } }, "sha512-SV8487gfTeWbDVyuRf3Vu8IUExMam/cWN7lfYLffDAgBsd9IwYAmENZWv2AunveCrfGBlSMqGVsaxui0ZGOcbQ=="],
+    "hive": ["hive@2.1.4", "", { "dependencies": { "hono": "4.9.7", "zod": "4.1.8" }, "peerDependencies": { "@types/bun": "latest", "drizzle-orm": "0.44.5", "typescript": "5.9.2" } }, "sha512-KAlVErCjvBfWQS2lb02ZxQLHMc778MHHw4r0oWsXkW+AlIca9u9A9NiAt+I54wDhJrano4w023Y94ndmv6bbeQ=="],
 
     "hono": ["hono@4.7.11", "", {}, "sha512-rv0JMwC0KALbbmwJDEnxvQCeJh+xbS3KEWW5PC9cMJ08Ur9xgatI0HmtgYZfOdOSOeYsp5LO2cOhdI8cLEbDEQ=="],
 

--- a/packages/blade-better-auth/package.json
+++ b/packages/blade-better-auth/package.json
@@ -42,7 +42,7 @@
     "@types/bun": "1.2.8",
     "blade-client": "workspace:*",
     "blade-compiler": "workspace:*",
-    "hive": "2.1.3",
+    "hive": "2.1.4",
     "tsdown": "0.15.2",
     "typescript": "5.8.2"
   },

--- a/packages/blade-cli/package.json
+++ b/packages/blade-cli/package.json
@@ -87,7 +87,7 @@
     "blade-compiler": "workspace:*",
     "blade-syntax": "workspace:*",
     "bun-bagel": "1.1.0",
-    "hive": "2.1.3",
+    "hive": "2.1.4",
     "tsdown": "0.15.2",
     "typescript": "5.8.3"
   }

--- a/packages/blade-client/package.json
+++ b/packages/blade-client/package.json
@@ -65,7 +65,7 @@
     "@types/bun": "1.2.4",
     "blade-compiler": "workspace:*",
     "blade-syntax": "workspace:*",
-    "hive": "2.1.3",
+    "hive": "2.1.4",
     "tsdown": "0.15.2",
     "typescript": "5.8.3"
   }

--- a/packages/blade-compiler/package.json
+++ b/packages/blade-compiler/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/bun": "1.1.14",
-    "hive": "2.1.3",
+    "hive": "2.1.4",
     "title": "4.0.1",
     "tsdown": "0.15.2",
     "typescript": "5.7.2"


### PR DESCRIPTION
Bumps `hive` to version `2.1.4`, landing various WebSocket and http layer improvements.