### PR TITLE
Improved stream selection logic

### DIFF
--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -62,7 +62,7 @@ const defaultDatabaseCaller: QueryHandlerOptions['databaseCaller'] = async (
   options,
 ) => {
   const { token, database, stream } = options;
-  const key = `${token}-${stream}`;
+  const key = `${token}${stream ? `-${stream}` : ''}`;
 
   if (!clients[key]) {
     const prefix = stream ? 'db-leader' : 'db';
@@ -126,7 +126,7 @@ export const runQueries = async <T extends ResultRecord>(
     return callDatabase(statements, {
       token: options.token as string,
       database: database as string,
-      stream: options.stream ?? false,
+      stream: options.stream,
     });
   });
 

--- a/packages/blade-client/src/types/utils.ts
+++ b/packages/blade-client/src/types/utils.ts
@@ -37,7 +37,7 @@ export interface QueryHandlerOptions {
    */
   databaseCaller?: (
     statements: Array<Statement>,
-    options: { token: string; database: string; stream: boolean },
+    options: { token: string; database: string; stream?: string },
   ) => Promise<DatabaseResult> | DatabaseResult;
 
   /**

--- a/packages/blade-client/src/types/utils.ts
+++ b/packages/blade-client/src/types/utils.ts
@@ -66,8 +66,13 @@ export interface QueryHandlerOptions {
     options: QueryHandlerOptions,
   ) => Promise<FormattedResults<ResultRecord>>;
 
-  /** Whether to re-use a single connection to ensure ordered queries. */
-  stream?: boolean;
+  /**
+   * A particular connection identifier to re-use for the provided queries.
+   *
+   * Useful for ensuring that multiple transactions are sent through the same connection,
+   * which guarantees their order during transport.
+   */
+  stream?: string;
 
   /**
    * Allows for extending the lifetime of the edge worker invocation until the

--- a/packages/blade-client/tests/integration/factory.test.ts
+++ b/packages/blade-client/tests/integration/factory.test.ts
@@ -26,7 +26,7 @@ describe('factory', () => {
           returning: true,
         },
       ],
-      { token: 'takashitoken', database: 'takashidatabase', stream: false },
+      { token: 'takashitoken', database: 'takashidatabase' },
     );
   });
 

--- a/packages/blade/private/server/utils/data.ts
+++ b/packages/blade/private/server/utils/data.ts
@@ -192,8 +192,7 @@ export const getClientConfig = (
       // If a write is being performed, and a `stream` option was provided, we need to
       // update the UI. Otherwise, we just need to execute the queries further below.
       if (writing && 'stream' in nestedOptions) {
-        const stream = nestedOptions.stream as unknown as string | undefined;
-        const { results } = await flush(queries, stream);
+        const { results } = await flush(queries, nestedOptions.stream);
 
         return results!
           .filter(({ type }) => type === 'write')

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -496,6 +496,7 @@ export const flushSession = async (
       options?.queries
         ? {
             queries: [
+              // These queries already have results, so they won't be modified.
               ...resumableReads,
               // Do not pass `options.queries` directly here, since it will get modified
               // in place and we don't want to resume the results of write queries.


### PR DESCRIPTION
This change applies a few more improvements that were missing from https://github.com/ronin-co/blade/pull/523.

As a result, the database caller (the function calling the database) now has access to the identifier of the current stream, which allows it to open multiple parallel streams for writes. We're not yet leveraging those, but will eventually.