### PR TITLE
Avoid blocking page render on write streams

### DIFF
--- a/packages/blade/private/server/utils/index.ts
+++ b/packages/blade/private/server/utils/index.ts
@@ -36,7 +36,7 @@ export class ResponseStream extends SSEStreamingApi {
    * The results of the read queries that were executed last. Allows for caching read
    * query results between flushes, to not run all read queries every time.
    */
-  lastResults: Array<QueryItemRead> = [];
+  lastResults: Array<QueryItemRead> | null = null;
 
   /** Allows for tracking whether the response is ready to be returned. */
   readonly headersReady: Promise<void>;

--- a/packages/blade/private/server/utils/index.ts
+++ b/packages/blade/private/server/utils/index.ts
@@ -36,7 +36,7 @@ export class ResponseStream extends SSEStreamingApi {
    * The results of the read queries that were executed last. Allows for caching read
    * query results between flushes, to not run all read queries every time.
    */
-  lastResults: Array<QueryItemRead> | null = null;
+  lastResults: Array<QueryItemRead> = [];
 
   /** Allows for tracking whether the response is ready to be returned. */
   readonly headersReady: Promise<void>;

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -462,30 +462,27 @@ export const flushSession = async (
       return {};
     }
 
-    // Whether one of the previously executed read queries can be streamed.
-    const streamedReads = stream.lastResults.some((result) => Boolean(result.stream));
-
     // By default, all read queries on a page path will be refreshed whenever the
     // surrounding function is called, meaning when the UI should be updated.
     //
     // If one of the read queries on that page path is marked with a `stream` property,
     // however, only that particular query will be updated, and only if a write query
     // with the same `stream` is being executed.
-    const resumableReads: Array<QueryItemRead> = streamedReads
-      ? stream.lastResults.filter((result) => {
-          const matchingStream = options?.queries?.some((query) => {
-            return query.stream === result.stream;
-          });
+    const resumableReads: Array<QueryItemRead> = (stream.lastResults || []).filter(
+      (result) => {
+        const matchingStream = options?.queries?.some((query) => {
+          return query.stream === result.stream;
+        });
 
-          // If a write query is being executed for which the same query stream was
-          // provided, we cannot resume a read result for it, since the read result is
-          // expected to be changed by the write query.
-          //
-          // If that isn't the case, however, we can resume it to avoid executing
-          // unnecessary read queries for which we already obtained results in the past.
-          return !matchingStream;
-        })
-      : [];
+        // If a write query is being executed for which the same query stream was
+        // provided, we cannot resume a read result for it, since the read result is
+        // expected to be changed by the write query.
+        //
+        // If that isn't the case, however, we can resume it to avoid executing
+        // unnecessary read queries for which we already obtained results in the past.
+        return !matchingStream;
+      },
+    );
 
     const { response, results } = await renderReactTree(
       new URL(stream.request.url),
@@ -515,10 +512,12 @@ export const flushSession = async (
     // Track the start time of the current update.
     stream.lastUpdate = currentStart;
 
-    // Track the results of the read queries that were executed last.
-    stream.lastResults = results.filter(({ type }) => {
-      return type === 'read';
+    const streamableReads = results.filter((item) => {
+      return item.type === 'read' && item.stream;
     }) as Array<QueryItemRead>;
+
+    // Track the results of the read queries that were executed last.
+    stream.lastResults = streamableReads.length > 0 ? streamableReads : null;
 
     await stream.writeChunk(correctBundle ? 'update' : 'update-bundle', response);
 

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -148,8 +148,10 @@ const obtainQueryResults = async (
     {} as Record<string, Array<Query>>,
   );
 
-  // If one of the provided queries must be streamed, then stream all of them.
-  const stream = sortedList.some((query) => Boolean(query.stream));
+  // If one of the provided queries is a write query and must be streamed, then stream
+  // all of them. Read-only transactions are generally not streamed since they should hit
+  // the edge replica of the database, if one exists.
+  const stream = sortedList.some((query) => query.type === 'write' && query.stream);
 
   let results: Record<string, FormattedResults<unknown>> = {};
 

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -73,14 +73,14 @@ const runQueriesWithTime = async (
   serverContext: ServerContext,
   path: string,
   queries: Record<string, Array<Query>>,
-  stream: boolean,
+  stream?: string,
 ): Promise<Record<string, FormattedResults<unknown>>> => {
   if (VERBOSE_LOGGING) console.log('-'.repeat(20));
 
   const start = Date.now();
 
   const config = getClientConfig(serverContext, 'write');
-  if (stream) config.stream = true;
+  if (stream) config.stream = stream;
 
   const databaseAmount = Object.keys(queries).length;
   const queryAmount = Object.values(queries).flat().length;
@@ -151,7 +151,9 @@ const obtainQueryResults = async (
   // If one of the provided queries is a write query and must be streamed, then stream
   // all of them. Read-only transactions are generally not streamed since they should hit
   // the edge replica of the database, if one exists.
-  const stream = sortedList.some((query) => query.type === 'write' && query.stream);
+  const stream = sortedList.find((query) => {
+    return query.type === 'write' && query.stream;
+  })?.stream;
 
   let results: Record<string, FormattedResults<unknown>> = {};
 

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -518,25 +518,9 @@ export const flushSession = async (
     stream.lastUpdate = currentStart;
 
     // Track the results of the read queries that were executed last.
-    for (const result of results) {
-      // Only read queries can be cached.
-      if (result.type !== 'read') continue;
-
-      const existing = stream.lastResults.find((oldItem) => {
-        return oldItem.query === result.query && oldItem.database === result.database;
-      });
-
-      // If the result wasn't cached before, cache it now.
-      if (!existing) {
-        stream.lastResults.push(result);
-        continue;
-      }
-
-      // If a write query was provided with the same stream, update the read query.
-      if (options?.queries?.some(({ stream }) => stream === result.stream)) {
-        existing.result = result.result;
-      }
-    }
+    stream.lastResults = results.filter(({ type }) => {
+      return type === 'read';
+    }) as Array<QueryItemRead>;
 
     await stream.writeChunk(correctBundle ? 'update' : 'update-bundle', response);
 

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -464,27 +464,30 @@ export const flushSession = async (
       return {};
     }
 
+    // Whether one of the previously executed read queries can be streamed.
+    const streamedReads = stream.lastResults.some((result) => Boolean(result.stream));
+
     // By default, all read queries on a page path will be refreshed whenever the
     // surrounding function is called, meaning when the UI should be updated.
     //
     // If one of the read queries on that page path is marked with a `stream` property,
     // however, only that particular query will be updated, and only if a write query
     // with the same `stream` is being executed.
-    const resumableReads: Array<QueryItemRead> = (stream.lastResults || []).filter(
-      (result) => {
-        const matchingStream = options?.queries?.some((query) => {
-          return query.stream === result.stream;
-        });
+    const resumableReads: Array<QueryItemRead> = streamedReads
+      ? stream.lastResults.filter((result) => {
+          const matchingStream = options?.queries?.some((query) => {
+            return query.stream === result.stream;
+          });
 
-        // If a write query is being executed for which the same query stream was
-        // provided, we cannot resume a read result for it, since the read result is
-        // expected to be changed by the write query.
-        //
-        // If that isn't the case, however, we can resume it to avoid executing
-        // unnecessary read queries for which we already obtained results in the past.
-        return !matchingStream;
-      },
-    );
+          // If a write query is being executed for which the same query stream was
+          // provided, we cannot resume a read result for it, since the read result is
+          // expected to be changed by the write query.
+          //
+          // If that isn't the case, however, we can resume it to avoid executing
+          // unnecessary read queries for which we already obtained results in the past.
+          return !matchingStream;
+        })
+      : [];
 
     const { response, results } = await renderReactTree(
       new URL(stream.request.url),
@@ -514,12 +517,10 @@ export const flushSession = async (
     // Track the start time of the current update.
     stream.lastUpdate = currentStart;
 
-    const streamableReads = results.filter((item) => {
-      return item.type === 'read' && item.stream;
-    }) as Array<QueryItemRead>;
-
     // Track the results of the read queries that were executed last.
-    stream.lastResults = streamableReads.length > 0 ? streamableReads : null;
+    stream.lastResults = results.filter(({ type }) => {
+      return type === 'read';
+    }) as Array<QueryItemRead>;
 
     await stream.writeChunk(correctBundle ? 'update' : 'update-bundle', response);
 


### PR DESCRIPTION
This change resolves a bug where the rendering of a page incorrectly gets blocked on write queries.