### PR TITLE
Skip diff queries while streaming

### DIFF
--- a/packages/blade-client/src/triggers/index.ts
+++ b/packages/blade-client/src/triggers/index.ts
@@ -588,7 +588,10 @@ export const applySyncTriggers = async <T extends ResultRecord>(
   return queries.flatMap((details, index) => {
     const { query, database } = details;
 
-    if (query.set || query.alter) {
+    // Only generate diff queries for queries of type `set` or `alter` and don't generate
+    // them if queries are currently being streamed, since developers expect fine-grained
+    // control over which queries are being sent in that case.
+    if ((query.set || query.alter) && !options.clientOptions.stream) {
       let newQuery: Query | undefined;
 
       if (query.set) {


### PR DESCRIPTION
For queries of type "set" and "alter", the client currently automatically produces queries for obtaining the "before" state of the records that were updated, such that developers can consume the "before and after" in triggers.

The change right here ensures that such diff queries are not generated while streaming, to ensure that only the slimmest amount of queries are streamed to avoid congesting the connection unnecessarily.