### PR TITLE
Ensure documentation external links don't use `NaiveLink`

### DIFF
--- a/docs/components/link.tsx
+++ b/docs/components/link.tsx
@@ -2,6 +2,18 @@ import { Link as NativeLink } from 'blade/client/components';
 import type { ComponentProps } from 'react';
 
 export const Link = ({ href, children }: ComponentProps<typeof NativeLink>) => {
+  const isExternal = typeof href === 'string' && href.startsWith('http');
+  if (isExternal)
+    return (
+      <a
+        className="text-cyan-600 transition-colors duration-200 hover:text-cyan-800"
+        href={href}
+        rel="noopener noreferrer"
+        target="_blank">
+        {children}
+      </a>
+    );
+
   return (
     <NativeLink
       className="text-cyan-600 transition-colors duration-200 hover:text-cyan-800"

--- a/docs/components/link.tsx
+++ b/docs/components/link.tsx
@@ -7,9 +7,7 @@ export const Link = ({ href, children }: ComponentProps<typeof NativeLink>) => {
     return (
       <a
         className="text-cyan-600 transition-colors duration-200 hover:text-cyan-800"
-        href={href}
-        rel="noopener noreferrer"
-        target="_blank">
+        href={href}>
         {children}
       </a>
     );

--- a/docs/components/link.tsx
+++ b/docs/components/link.tsx
@@ -1,11 +1,12 @@
 import { Link as NativeLink } from 'blade/client/components';
+import type { ComponentProps } from 'react';
 
-export const Link = ({ href, children }: { href: string; children: React.ReactNode }) => {
+export const Link = ({ href, children }: ComponentProps<typeof NativeLink>) => {
   return (
-    <NativeLink href={href}>
-      <a className="text-cyan-600 transition-colors duration-200 hover:text-cyan-800">
-        {children}
-      </a>
+    <NativeLink
+      className="text-cyan-600 transition-colors duration-200 hover:text-cyan-800"
+      href={href}>
+      {children}
     </NativeLink>
   );
 };


### PR DESCRIPTION
This PR updates the custom `Link` component used in our documentation to only use the `NativeLink` component for local / relative urls. Any external link will now use a regular anchor element.