### PR TITLE
Ensure correct browser history order

### DIFF
--- a/packages/blade/private/client/components/history.tsx
+++ b/packages/blade/private/client/components/history.tsx
@@ -28,7 +28,7 @@ const HistoryContent = ({ children }: HistoryContentProps) => {
       const newLocation = window.location;
       const pathname = newLocation.pathname + newLocation.search + newLocation.hash;
 
-      transitionPage(pathname);
+      transitionPage(pathname, { updateAddressBar: false });
     };
 
     window.addEventListener('popstate', pageChanged);
@@ -44,8 +44,10 @@ const HistoryContent = ({ children }: HistoryContentProps) => {
       return;
     }
 
-    if (universalContext.addressBarInSync)
+    if (universalContext.addressBarInSync) {
+      console.log('UPDATE URL', populatedPathname + search);
       history.pushState({}, '', populatedPathname + search);
+    }
   }, [populatedPathname + search]);
 
   // Ensure that the scroll position is reset whenever the page changes.

--- a/packages/blade/private/client/components/history.tsx
+++ b/packages/blade/private/client/components/history.tsx
@@ -28,6 +28,8 @@ const HistoryContent = ({ children }: HistoryContentProps) => {
       const newLocation = window.location;
       const pathname = newLocation.pathname + newLocation.search + newLocation.hash;
 
+      // Don't update the address bar, since the browser already updated it. This also
+      // ensures that no additional state entry is pushed into the history.
       transitionPage(pathname, { updateAddressBar: false });
     };
 
@@ -45,7 +47,6 @@ const HistoryContent = ({ children }: HistoryContentProps) => {
     }
 
     if (universalContext.addressBarInSync) {
-      console.log('UPDATE URL', populatedPathname + search);
       history.pushState({}, '', populatedPathname + search);
     }
   }, [populatedPathname + search]);

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -250,9 +250,7 @@ app.post('*', async (c) => {
 
   const body = await c.req.parseBody<ClientTransition>({ all: true });
 
-  const options: PageFetchingOptions = body.options
-    ? JSON.parse(body.options)
-    : undefined;
+  const options: PageFetchingOptions = body.options ? JSON.parse(body.options) : {};
   const files = body.files
     ? Array.isArray(body.files)
       ? body.files
@@ -270,7 +268,7 @@ app.post('*', async (c) => {
 
   let queries: Array<QueryItemWrite> | undefined;
 
-  if (options?.queries) {
+  if (options.queries) {
     queries = options.queries;
 
     // Only accept DML write queries to be provided from the client.

--- a/packages/blade/private/server/worker/index.ts
+++ b/packages/blade/private/server/worker/index.ts
@@ -288,7 +288,12 @@ app.post('*', async (c) => {
 
   const stream = new ResponseStream(c.req.raw);
 
-  flushSession(stream, correctBundle, { queries, repeat: subscribe });
+  flushSession(stream, correctBundle, {
+    queries,
+    repeat: subscribe,
+    updateAddressBar: options.updateAddressBar,
+    errorFallback: options.errorFallback,
+  });
 
   if (subscribe) {
     const id = crypto.randomUUID();

--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -425,6 +425,10 @@ export const flushSession = async (
     queries?: Array<QueryItemWrite>;
     /** Whether to repeat the flush at an interval. */
     repeat?: boolean;
+    /** Whether the flush should initially update the address bar. */
+    updateAddressBar?: PageFetchingOptions['updateAddressBar'];
+    /** The page that should be rendered if the write queries fail to execute. */
+    errorFallback?: PageFetchingOptions['errorFallback'];
   },
 ): Promise<{ results?: Collected['queries'] }> => {
   // If the client is no longer connected, don't try to push an update. This therefore
@@ -491,6 +495,8 @@ export const flushSession = async (
       {
         waitUntil: getWaitUntil(),
         flushSession: options?.repeat ? nestedFlushSession : undefined,
+        updateAddressBar: options?.updateAddressBar,
+        errorFallback: options?.errorFallback,
       },
       options?.queries
         ? {


### PR DESCRIPTION
At the moment, the browser history does not get managed correctly, due to a bug that was introduced recently.

The change right here ensures that browser history entries are added correctly.