### PR TITLE
Make external docs links open in new tab

### DIFF
--- a/docs/components/link.tsx
+++ b/docs/components/link.tsx
@@ -1,22 +1,27 @@
 import { Link as NativeLink } from 'blade/client/components';
-import type { ComponentProps } from 'react';
+import type { AnchorHTMLAttributes, ReactElement } from 'react';
 
-export const Link = ({ href, children }: ComponentProps<typeof NativeLink>) => {
+interface LinkProps extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  href: string;
+  children: ReactElement;
+}
+
+export const Link = ({ href, children }: LinkProps) => {
   const isExternal = typeof href === 'string' && href.startsWith('http');
+
+  const props: LinkProps = {
+    href,
+    className: 'text-cyan-600 transition-colors duration-200 hover:text-cyan-800',
+    children,
+  };
+
   if (isExternal)
     return (
       <a
-        className="text-cyan-600 transition-colors duration-200 hover:text-cyan-800"
-        href={href}>
-        {children}
-      </a>
+        {...props}
+        target="_blank"
+        rel="noreferrer"
+      />
     );
-
-  return (
-    <NativeLink
-      className="text-cyan-600 transition-colors duration-200 hover:text-cyan-800"
-      href={href}>
-      {children}
-    </NativeLink>
-  );
+  return <NativeLink {...props} />;
 };

--- a/docs/components/link.tsx
+++ b/docs/components/link.tsx
@@ -15,7 +15,7 @@ export const Link = ({ href, children }: LinkProps) => {
     children,
   };
 
-  if (isExternal)
+  if (isExternal) {
     return (
       <a
         {...props}
@@ -23,5 +23,7 @@ export const Link = ({ href, children }: LinkProps) => {
         rel="noreferrer"
       />
     );
+  }
+
   return <NativeLink {...props} />;
 };


### PR DESCRIPTION
This change ensures that external links in the docs open in a new tab and closes https://github.com/ronin-co/blade/issues/456.