### PR TITLE
Ensure React 19.2.0 support on CF Workers

### DIFF
--- a/packages/blade/private/server/worker/tree.ts
+++ b/packages/blade/private/server/worker/tree.ts
@@ -12,7 +12,7 @@ import getValue from 'get-value';
 import { sleep } from 'radash';
 import React, { type ReactNode } from 'react';
 // @ts-expect-error `@types/react-dom` is missing types for this file.
-import { renderToReadableStream as renderToReadableStreamInitial } from 'react-dom/server.browser';
+import { renderToReadableStream as renderToReadableStreamInitial } from 'react-dom/server.edge';
 import { serializeError } from 'serialize-error';
 import { pages as pageList } from 'server-list';
 

--- a/packages/blade/tsdown.config.ts
+++ b/packages/blade/tsdown.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     'react/jsx-runtime',
     'react-dom',
     'react-dom/client',
-    'react-dom/server.browser',
+    'react-dom/server.edge',
     'typescript',
     'undici',
   ],


### PR DESCRIPTION
https://github.com/ronin-co/blade/pull/539 broke Cloudflare Workers. The change right here makes them work again.