### PR TITLE
Correctly scope `public` directory

### DIFF
--- a/docs/pages/deploying.mdx
+++ b/docs/pages/deploying.mdx
@@ -2,6 +2,16 @@
 title: Deploying
 ---
 
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
 # Deploying
 
 Blade was designed from the ground up to be easy to deploy anywhere. Its build
@@ -16,9 +26,33 @@ blade build
 ```
 
 This command will generate a directory named `.blade/dist/` in the current directory,
-which contains the compiled application. Specifically, the compilation process
-includes bundling dependencies, tree-shaking, eliminating dead code, and
-minfiying it.
+which contains the compiled application. Specifically, the compilation process includes
+bundling dependencies, tree-shaking, eliminating dead code, and minfiying it.
+
+These are the contents of the directory:
+
+<Table>
+  <TableHeader>
+    <TableRow>
+      <TableHead>Name</TableHead>
+      <TableHead>Purpose</TableHead>
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    <TableRow>
+      <TableCell>`.blade/dist`</TableCell>
+      <TableCell>All build output</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell>`.blade/dist/public`</TableCell>
+      <TableCell>Build output that can be served to visitors</TableCell>
+    </TableRow>
+    <TableRow>
+      <TableCell>`.blade/dist/edge-worker.js`</TableCell>
+      <TableCell>A [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) that can be run on the server</TableCell>
+    </TableRow>
+  </TableBody>
+</Table>
 
 ## Providers
 

--- a/docs/pages/deploying.mdx
+++ b/docs/pages/deploying.mdx
@@ -27,7 +27,7 @@ blade build
 
 This command will generate a directory named `.blade/dist/` in the current directory,
 which contains the compiled application. Specifically, the compilation process includes
-bundling dependencies, tree-shaking, eliminating dead code, and minfiying it.
+bundling dependencies, tree-shaking, eliminating dead code, and minifying it.
 
 These are the contents of the directory:
 

--- a/docs/pages/deploying.mdx
+++ b/docs/pages/deploying.mdx
@@ -45,11 +45,11 @@ These are the contents of the directory:
     </TableRow>
     <TableRow>
       <TableCell>`.blade/dist/public`</TableCell>
-      <TableCell>Build output that can be served to visitors</TableCell>
+      <TableCell>Build output to be served publicly at the root of your domain</TableCell>
     </TableRow>
     <TableRow>
       <TableCell>`.blade/dist/edge-worker.js`</TableCell>
-      <TableCell>A [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) that can be run on the server</TableCell>
+      <TableCell>A [Web Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers) to be run on a server</TableCell>
     </TableRow>
   </TableBody>
 </Table>

--- a/packages/blade/private/shell/constants.ts
+++ b/packages/blade/private/shell/constants.ts
@@ -6,8 +6,6 @@ import gradient from 'gradient-string';
 const currentFilePath = fileURLToPath(import.meta.url);
 export const sourceDirPath = dirname(currentFilePath);
 
-export const publicDirectoryName = 'public';
-export const publicDirectory = resolve(process.cwd(), publicDirectoryName);
 export const outputDirectoryName = join('.blade', 'dist');
 export const outputDirectory = resolve(process.cwd(), outputDirectoryName);
 

--- a/packages/blade/private/shell/constants.ts
+++ b/packages/blade/private/shell/constants.ts
@@ -3,11 +3,15 @@ import { fileURLToPath } from 'node:url';
 import chalk from 'chalk';
 import gradient from 'gradient-string';
 
+import { PUBLIC_ASSET_PREFIX } from '@/private/universal/utils/constants';
+
 const currentFilePath = fileURLToPath(import.meta.url);
 export const sourceDirPath = dirname(currentFilePath);
 
 export const outputDirectoryName = join('.blade', 'dist');
 export const outputDirectory = resolve(process.cwd(), outputDirectoryName);
+
+export const publicOutputDirectory = join(outputDirectory, PUBLIC_ASSET_PREFIX);
 
 export const tsconfigFilename = resolve(process.cwd(), 'tsconfig.json');
 export const packageMetaFilename = resolve(process.cwd(), 'package.json');

--- a/packages/blade/private/shell/constants.ts
+++ b/packages/blade/private/shell/constants.ts
@@ -6,8 +6,10 @@ import gradient from 'gradient-string';
 const currentFilePath = fileURLToPath(import.meta.url);
 export const sourceDirPath = dirname(currentFilePath);
 
-export const publicDirectory = resolve(process.cwd(), 'public');
-export const outputDirectory = resolve(process.cwd(), '.blade', 'dist');
+export const publicDirectoryName = 'public';
+export const publicDirectory = resolve(process.cwd(), publicDirectoryName);
+export const outputDirectoryName = join('.blade', 'dist');
+export const outputDirectory = resolve(process.cwd(), outputDirectoryName);
 
 export const tsconfigFilename = resolve(process.cwd(), 'tsconfig.json');
 export const packageMetaFilename = resolve(process.cwd(), 'package.json');

--- a/packages/blade/private/shell/listener.ts
+++ b/packages/blade/private/shell/listener.ts
@@ -53,7 +53,7 @@ export const serve = async (
     // Serve files located in the `public` directory.
     app.use('*', serveStatic({ root: PUBLIC_ASSET_PREFIX }));
   } else {
-    // Source maps should only be accessible during development.
+    // Source maps should not be accessible in production.
     app.use(`/${CLIENT_ASSET_PREFIX}/:path{.+\\.map}`, async (c) => c.notFound());
   }
 

--- a/packages/blade/private/shell/listener.ts
+++ b/packages/blade/private/shell/listener.ts
@@ -5,13 +5,12 @@ import chalk from 'chalk';
 import { Hono } from 'hono';
 import { compress } from 'hono/compress';
 
-import {
-  loggingPrefixes,
-  outputDirectoryName,
-  publicDirectoryName,
-} from '@/private/shell/constants';
+import { loggingPrefixes, outputDirectoryName } from '@/private/shell/constants';
 import { polyfillCompressionStream } from '@/private/shell/utils/polyfills';
-import { CLIENT_ASSET_PREFIX } from '@/private/universal/utils/constants';
+import {
+  CLIENT_ASSET_PREFIX,
+  PUBLIC_ASSET_PREFIX,
+} from '@/private/universal/utils/constants';
 
 export interface ServerState {
   module?: Promise<{ default: Hono }>;
@@ -52,7 +51,7 @@ export const serve = async (
 
   if (environment === 'development') {
     // Serve files located in the `public` directory.
-    app.use('*', serveStatic({ root: publicDirectoryName }));
+    app.use('*', serveStatic({ root: PUBLIC_ASSET_PREFIX }));
   } else {
     // Source maps should only be accessible during development.
     app.use(`/${CLIENT_ASSET_PREFIX}/:path{.+\\.map}`, async (c) => c.notFound());
@@ -64,7 +63,7 @@ export const serve = async (
     serveStatic({
       // It's extremely important for requests to be scoped to the public output
       // directory, since server code could otherwise be read.
-      root: path.join(outputDirectoryName, publicDirectoryName),
+      root: path.join(outputDirectoryName, PUBLIC_ASSET_PREFIX),
       onFound: (_path, c) => {
         c.header('Cache-Control', 'public, max-age=31536000, immutable');
       },

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -13,7 +13,7 @@ import MagicString from 'magic-string';
 import type { Plugin as RolldownPlugin } from 'rolldown';
 
 import {
-  outputDirectory,
+  publicOutputDirectory,
   routerInputFile,
   styleInputFile,
 } from '@/private/shell/constants';
@@ -268,7 +268,7 @@ export const getProviderLoader = (
 
     // Copy hard-coded static assets into output directory.
     if (await exists(publicSource)) {
-      await cp(publicSource, path.join(outputDirectory, PUBLIC_ASSET_PREFIX), {
+      await cp(publicSource, publicOutputDirectory, {
         recursive: true,
       });
     }

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -14,8 +14,6 @@ import type { Plugin as RolldownPlugin } from 'rolldown';
 
 import {
   outputDirectory,
-  publicDirectory,
-  publicDirectoryName,
   routerInputFile,
   styleInputFile,
 } from '@/private/shell/constants';
@@ -37,6 +35,7 @@ import {
 } from '@/private/shell/utils/providers';
 import type { DeploymentProvider } from '@/private/universal/types/util';
 import { generateUniqueId } from '@/private/universal/utils';
+import { PUBLIC_ASSET_PREFIX } from '@/private/universal/utils/constants';
 
 export const getClientReferenceLoader = (): RolldownPlugin => ({
   name: 'Client Reference Loader',
@@ -265,9 +264,11 @@ export const getProviderLoader = (
   async writeBundle() {
     if (environment !== 'production') return;
 
+    const publicSource = path.join(process.cwd(), PUBLIC_ASSET_PREFIX);
+
     // Copy hard-coded static assets into output directory.
-    if (await exists(publicDirectory)) {
-      await cp(publicDirectory, path.join(outputDirectory, publicDirectoryName), {
+    if (await exists(publicSource)) {
+      await cp(publicSource, path.join(outputDirectory, PUBLIC_ASSET_PREFIX), {
         recursive: true,
       });
     }

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -268,9 +268,7 @@ export const getProviderLoader = (
 
     // Copy hard-coded static assets into output directory.
     if (await exists(publicSource)) {
-      await cp(publicSource, publicOutputDirectory, {
-        recursive: true,
-      });
+      await cp(publicSource, publicOutputDirectory, { recursive: true });
     }
 
     switch (provider) {

--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -15,6 +15,7 @@ import type { Plugin as RolldownPlugin } from 'rolldown';
 import {
   outputDirectory,
   publicDirectory,
+  publicDirectoryName,
   routerInputFile,
   styleInputFile,
 } from '@/private/shell/constants';
@@ -266,7 +267,9 @@ export const getProviderLoader = (
 
     // Copy hard-coded static assets into output directory.
     if (await exists(publicDirectory)) {
-      await cp(publicDirectory, outputDirectory, { recursive: true });
+      await cp(publicDirectory, path.join(outputDirectory, publicDirectoryName), {
+        recursive: true,
+      });
     }
 
     switch (provider) {

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -26,7 +26,7 @@ import {
 import { composeEnvironmentVariables, exists } from '@/private/shell/utils';
 import { getProvider } from '@/private/shell/utils/providers';
 import { generateUniqueId } from '@/private/universal/utils';
-import { getOutputFile } from '@/private/universal/utils/paths';
+import { getOutputFile, getPublicFile } from '@/private/universal/utils/paths';
 
 export interface VirtualFileItem {
   /**
@@ -156,11 +156,11 @@ export const composeBuildContext = async (
         banner: `if(!import.meta.env){import.meta.env={}};import.meta.env.__BLADE_BUNDLE_ID='${bundleId}';`,
         minify: environment === 'production',
         entryFileNames: (chunk) => {
-          if (chunk.name === 'client') return getOutputFile(bundleId, 'js');
+          if (chunk.name === 'client') return getPublicFile(bundleId, 'js');
           return '[name].js';
         },
-        assetFileNames: getOutputFile(bundleId, 'css'),
-        chunkFileNames: getOutputFile(bundleId, 'js', true),
+        assetFileNames: getPublicFile(bundleId, 'css'),
+        chunkFileNames: getPublicFile(bundleId, 'js', true),
       };
 
       try {

--- a/packages/blade/private/shell/utils/providers.ts
+++ b/packages/blade/private/shell/utils/providers.ts
@@ -199,10 +199,10 @@ export const transformToNetlifyOutput = async (): Promise<void> => {
   // Since edge functions do not offer a `preferStatic` option, we need to manually
   // provide a list of all static assets to not be routed to the edge function.
   const staticAssets = new Array<string>();
-  const files = await readdir(outputDirectory, { recursive: true });
+  const files = await readdir(publicOutputDirectory, { recursive: true });
 
   for (const file of files) {
-    if (!file.endsWith('.map')) staticAssets.push(`/${file}`);
+    if (!file.endsWith('.map')) staticAssets.push(`/public/${file}`);
   }
 
   await Promise.all([

--- a/packages/blade/private/shell/utils/providers.ts
+++ b/packages/blade/private/shell/utils/providers.ts
@@ -202,7 +202,7 @@ export const transformToNetlifyOutput = async (): Promise<void> => {
   const files = await readdir(publicOutputDirectory, { recursive: true });
 
   for (const file of files) {
-    if (!file.endsWith('.map')) staticAssets.push(`/public/${file}`);
+    if (!file.endsWith('.map')) staticAssets.push(`/${file}`);
   }
 
   await Promise.all([

--- a/packages/blade/private/universal/utils/constants.ts
+++ b/packages/blade/private/universal/utils/constants.ts
@@ -1,4 +1,5 @@
 export const CLIENT_ASSET_PREFIX = 'client';
+export const PUBLIC_ASSET_PREFIX = 'public';
 
 export const DEFAULT_PAGE_PATH = 'blade-default-pages';
 

--- a/packages/blade/private/universal/utils/paths.ts
+++ b/packages/blade/private/universal/utils/paths.ts
@@ -1,3 +1,4 @@
+import { publicDirectoryName } from '@/private/shell/constants';
 import { CLIENT_ASSET_PREFIX } from '@/private/universal/utils/constants';
 
 // This helper takes a link destination (such as `/[space]/settings`) and replaces all
@@ -45,4 +46,8 @@ export const populatePathSegments = (
 
 export const getOutputFile = (bundleId: string, ext: 'js' | 'css', chunk?: boolean) => {
   return `${CLIENT_ASSET_PREFIX}/${chunk ? 'chunk' : 'main'}.${bundleId}.${ext}`;
+};
+
+export const getPublicFile: typeof getOutputFile = (...args) => {
+  return `${publicDirectoryName}/${getOutputFile(...args)}`;
 };

--- a/packages/blade/private/universal/utils/paths.ts
+++ b/packages/blade/private/universal/utils/paths.ts
@@ -1,5 +1,7 @@
-import { publicDirectoryName } from '@/private/shell/constants';
-import { CLIENT_ASSET_PREFIX } from '@/private/universal/utils/constants';
+import {
+  CLIENT_ASSET_PREFIX,
+  PUBLIC_ASSET_PREFIX,
+} from '@/private/universal/utils/constants';
 
 // This helper takes a link destination (such as `/[space]/settings`) and replaces all
 // the path segments that might already have a value in the current URL. For example, if
@@ -49,5 +51,5 @@ export const getOutputFile = (bundleId: string, ext: 'js' | 'css', chunk?: boole
 };
 
 export const getPublicFile: typeof getOutputFile = (...args) => {
-  return `${publicDirectoryName}/${getOutputFile(...args)}`;
+  return `${PUBLIC_ASSET_PREFIX}/${getOutputFile(...args)}`;
 };


### PR DESCRIPTION
This change closes #538 by refining the structure of Blade's build output (see docs in the diff).