### PR TITLE
Make `blade types` work locally

### DIFF
--- a/packages/blade-cli/src/commands/apply.ts
+++ b/packages/blade-cli/src/commands/apply.ts
@@ -76,7 +76,7 @@ export default async (
     spinner.succeed('Successfully applied migration');
 
     // If desired, generate new TypeScript types.
-    if (!flags['skip-types']) await types(appToken);
+    if (!flags['skip-types']) await types(flags, []);
 
     process.exit(0);
   } catch (err) {

--- a/packages/blade-cli/src/commands/types.ts
+++ b/packages/blade-cli/src/commands/types.ts
@@ -6,7 +6,6 @@ import { generateZodSchema } from 'blade-codegen/zod';
 import { CompilerError } from 'blade-compiler';
 
 import { BLADE_CONFIG_DIR, type BaseFlags, getModelDefinitions } from '@/src/utils/misc';
-import { getModels } from '@/src/utils/model';
 import { spinner as ora } from '@/src/utils/spinner';
 import {
   TYPES_DTS_FILE_NAME,
@@ -35,8 +34,8 @@ export default async (flags: TypesFlags, positionals: Array<string>): Promise<vo
     if (!configDirExists) await fs.mkdir(configDir);
 
     const modelsInCodePath =
-      positionals[positionals.indexOf('diff') + 1] &&
-      path.join(process.cwd(), positionals[positionals.indexOf('diff') + 1]);
+      positionals[positionals.indexOf('types') + 1] &&
+      path.join(process.cwd(), positionals[positionals.indexOf('types') + 1]);
 
     const models = (await getModelDefinitions(modelsInCodePath)) as Parameters<
       typeof generateZodSchema

--- a/packages/blade-cli/src/commands/types.ts
+++ b/packages/blade-cli/src/commands/types.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import type { parseArgs } from 'node:util';
 import { generate } from 'blade-codegen';
 import { generateZodSchema } from 'blade-codegen/zod';
-import { CompilerError } from 'blade-compiler';
+import { CompilerError, Transaction } from 'blade-compiler';
 
 import { BLADE_CONFIG_DIR, type BaseFlags, getModelDefinitions } from '@/src/utils/misc';
 import { spinner as ora } from '@/src/utils/spinner';
@@ -37,9 +37,9 @@ export default async (flags: TypesFlags, positionals: Array<string>): Promise<vo
       positionals[positionals.indexOf('types') + 1] &&
       path.join(process.cwd(), positionals[positionals.indexOf('types') + 1]);
 
-    const models = (await getModelDefinitions(modelsInCodePath)) as Parameters<
-      typeof generateZodSchema
-    >[0];
+    const rawModels = await getModelDefinitions(modelsInCodePath);
+    const { models: modelsWithDefaults } = new Transaction([], { models: rawModels });
+    const models = modelsWithDefaults.filter((item) => !item.system);
 
     if (flags?.zod) {
       const zodSchemas = generateZodSchema(models);

--- a/packages/blade-cli/src/index.ts
+++ b/packages/blade-cli/src/index.ts
@@ -85,7 +85,7 @@ export const run = async (config: { version: string }): Promise<void> => {
   }
 
   // `types` sub command.
-  if (normalizedPositionals.includes('types')) return generateTypes(appToken, flags);
+  if (normalizedPositionals.includes('types')) return generateTypes(flags, positionals);
 
   // `pull` sub command
   if (normalizedPositionals.includes('pull')) {

--- a/packages/blade-cli/tests/index.test.ts
+++ b/packages/blade-cli/tests/index.test.ts
@@ -756,7 +756,7 @@ describe('CLI', () => {
     test('generate zod schema', async () => {
       process.argv = ['bun', 'blade', 'types', '--zod'];
 
-      spyOn(modelModule, 'getModels').mockResolvedValue([
+      spyOn(miscModule, 'getModelDefinitions').mockResolvedValue([
         {
           slug: 'test',
           fields: {

--- a/packages/blade-codegen/src/constants/schema.ts
+++ b/packages/blade-codegen/src/constants/schema.ts
@@ -2,9 +2,9 @@ import { SyntaxKind, factory } from 'typescript';
 
 import { identifiers } from '@/src/constants/identifiers';
 
+import type { ModelField } from 'blade-compiler';
 import type { TypeNode } from 'typescript';
 
-import type { ModelField } from '@/src/types/model';
 import type { QueryType } from '@/src/types/query';
 
 /**
@@ -21,7 +21,7 @@ export const MODEL_TYPE_TO_SYNTAX_KIND_KEYWORD = {
   link: factory.createKeywordTypeNode(SyntaxKind.UnknownKeyword),
   number: factory.createKeywordTypeNode(SyntaxKind.NumberKeyword),
   string: factory.createKeywordTypeNode(SyntaxKind.StringKeyword),
-} satisfies Record<ModelField['type'], TypeNode>;
+} satisfies Record<NonNullable<ModelField['type']>, TypeNode>;
 
 /**
  * A simple object mapping all DML query types to their human readable string.

--- a/packages/blade-codegen/src/generators/comment.ts
+++ b/packages/blade-codegen/src/generators/comment.ts
@@ -1,7 +1,7 @@
 import { READABLE_DML_QUERY_TYPES } from '@/src/constants/schema';
 
-import type { Model } from '@/src/types/model';
 import type { QueryType } from '@/src/types/query';
+import type { PopulatedModel } from 'blade-compiler';
 
 interface GenerateQueryTypeCommentResult {
   singular: string;
@@ -17,7 +17,7 @@ interface GenerateQueryTypeCommentResult {
  * @returns An object containing both the singular and plural comment strings.
  */
 export const generateQueryTypeComment = (
-  model: Model,
+  model: PopulatedModel,
   queryType: QueryType,
 ): GenerateQueryTypeCommentResult => ({
   singular: `* ${READABLE_DML_QUERY_TYPES[queryType]} a single ${model.name ?? model.slug} record `,

--- a/packages/blade-codegen/src/generators/model.ts
+++ b/packages/blade-codegen/src/generators/model.ts
@@ -6,10 +6,10 @@ import { triggerOptionsInterface } from '@/src/declarations';
 import { convertToPascalCase } from '@/src/utils/slug';
 import { mapRoninFieldToTypeNode, remapNestedFields } from '@/src/utils/types';
 
+import type { PopulatedModel } from 'blade-compiler';
 import type { TypeAliasDeclaration, TypeParameterDeclaration } from 'typescript';
 
 import type { ModelField } from '@/src/types/model';
-import type { PopulatedModel } from 'blade-compiler';
 
 /**
  * Generate all required type definitions for a provided schema model.

--- a/packages/blade-codegen/src/generators/model.ts
+++ b/packages/blade-codegen/src/generators/model.ts
@@ -1,4 +1,4 @@
-import { SyntaxKind, addSyntheticLeadingComment, factory } from 'typescript';
+import { SyntaxKind, factory } from 'typescript';
 
 import { identifiers, typeArgumentIdentifiers } from '@/src/constants/identifiers';
 import { DEFAULT_FIELD_SLUGS } from '@/src/constants/schema';
@@ -8,7 +8,8 @@ import { mapRoninFieldToTypeNode, remapNestedFields } from '@/src/utils/types';
 
 import type { TypeAliasDeclaration, TypeParameterDeclaration } from 'typescript';
 
-import type { Model, ModelField } from '@/src/types/model';
+import type { ModelField } from '@/src/types/model';
+import type { PopulatedModel } from 'blade-compiler';
 
 /**
  * Generate all required type definitions for a provided schema model.
@@ -20,7 +21,9 @@ import type { Model, ModelField } from '@/src/types/model';
  *
  * @returns An array of type nodes to be added to the `index.d.ts` file.
  */
-export const generateModelTypes = (models: Array<Model>): Array<TypeAliasDeclaration> => {
+export const generateModelTypes = (
+  models: Array<PopulatedModel>,
+): Array<TypeAliasDeclaration> => {
   const nodes = new Array<TypeAliasDeclaration>(triggerOptionsInterface);
 
   for (const model of models) {
@@ -181,27 +184,7 @@ export const generateModelTypes = (models: Array<Model>): Array<TypeAliasDeclara
       ]),
     );
 
-    // If the model does not have a summary / description
-    // then we can continue to the next iteration & not add any comments.
-    if (!model.summary) {
-      nodes.push(singularModelTypeDec, pluralModelTypeDec);
-      continue;
-    }
-
-    nodes.push(
-      addSyntheticLeadingComment(
-        singularModelTypeDec,
-        SyntaxKind.MultiLineCommentTrivia,
-        `*\n * ${model.summary}\n `,
-        true,
-      ),
-      addSyntheticLeadingComment(
-        pluralModelTypeDec,
-        SyntaxKind.MultiLineCommentTrivia,
-        `*\n * ${model.summary}\n `,
-        true,
-      ),
-    );
+    nodes.push(singularModelTypeDec, pluralModelTypeDec);
   }
 
   return nodes;

--- a/packages/blade-codegen/src/generators/model.ts
+++ b/packages/blade-codegen/src/generators/model.ts
@@ -6,10 +6,8 @@ import { triggerOptionsInterface } from '@/src/declarations';
 import { convertToPascalCase } from '@/src/utils/slug';
 import { mapRoninFieldToTypeNode, remapNestedFields } from '@/src/utils/types';
 
-import type { PopulatedModel } from 'blade-compiler';
+import type { ModelField, PopulatedModel } from 'blade-compiler';
 import type { TypeAliasDeclaration, TypeParameterDeclaration } from 'typescript';
-
-import type { ModelField } from '@/src/types/model';
 
 /**
  * Generate all required type definitions for a provided schema model.

--- a/packages/blade-codegen/src/generators/namespaces.ts
+++ b/packages/blade-codegen/src/generators/namespaces.ts
@@ -6,9 +6,8 @@ import { generateQueryTypeComment } from '@/src/generators/comment';
 import { generateUsingSyntax, generateWithSyntax } from '@/src/generators/syntax';
 import { convertToPascalCase } from '@/src/utils/slug';
 
+import type { PopulatedModel } from 'blade-compiler';
 import type { Statement, TypeAliasDeclaration } from 'typescript';
-
-import type { Model } from '@/src/types/model';
 
 /**
  * Generate syntax namespaces for each model.
@@ -34,7 +33,7 @@ import type { Model } from '@/src/types/model';
  *
  * @returns Array of module declarations representing the namespaces.
  */
-export const generateNamespaces = (models: Array<Model>): Array<Statement> => {
+export const generateNamespaces = (models: Array<PopulatedModel>): Array<Statement> => {
   const moduleDeclarations = new Array<Statement>();
 
   /**

--- a/packages/blade-codegen/src/generators/syntax.ts
+++ b/packages/blade-codegen/src/generators/syntax.ts
@@ -7,7 +7,7 @@ import { convertToPascalCase } from '@/src/utils/slug';
 
 import type { IntersectionTypeNode, TypeAliasDeclaration, TypeNode } from 'typescript';
 
-import type { Model } from '@/src/types/model';
+import type { PopulatedModel } from 'blade-compiler';
 
 /**
  * Generate the syntax for a `using` query.
@@ -20,7 +20,7 @@ import type { Model } from '@/src/types/model';
  * @returns An IntersectionTypeNode representing the `using` syntax.
  */
 export const generateUsingSyntax = (
-  model: Model,
+  model: PopulatedModel,
   modelNode: TypeNode,
   promise: boolean,
   plural: boolean,
@@ -179,7 +179,7 @@ export const generateUsingSyntax = (
  * @returns A TypeAliasDeclaration representing the `with` syntax.
  */
 export const generateWithSyntax = (
-  model: Model,
+  model: PopulatedModel,
   modelNode: TypeNode,
   promise: boolean,
 ): TypeAliasDeclaration => {

--- a/packages/blade-codegen/src/index.ts
+++ b/packages/blade-codegen/src/index.ts
@@ -36,9 +36,8 @@ import { generateNamespaces } from '@/src/generators/namespaces';
 import { printNodes } from '@/src/utils/print';
 import { convertToPascalCase } from '@/src/utils/slug';
 
+import type { PopulatedModel } from 'blade-compiler';
 import type { Node, TypeAliasDeclaration } from 'typescript';
-
-import type { Model } from '@/src/types/model';
 
 /**
  * Generates the complete `index.d.ts` file for a list of RONIN models.
@@ -47,7 +46,7 @@ import type { Model } from '@/src/types/model';
  *
  * @returns A string of the complete `index.d.ts` file.
  */
-export const generate = (models: Array<Model>): string => {
+export const generate = (models: Array<PopulatedModel>): string => {
   // Each node represents any kind of "block" like
   // an import statement, interface, namespace, etc.
   const nodes = new Array<Node>(importBladeCompilerQueryTypesType, importBladeUtilsType);

--- a/packages/blade-codegen/src/types/model.ts
+++ b/packages/blade-codegen/src/types/model.ts
@@ -1,23 +1,7 @@
-import type {
-  Model as PartialModel,
-  ModelField as PartialModelField,
-} from 'blade-compiler';
+import type { ModelField as PartialModelField } from 'blade-compiler';
 
 type RecursiveRequired<T> = {
   [K in keyof T]-?: T[K] extends object ? RecursiveRequired<T[K]> : T[K];
 };
-
-interface BaseModel {
-  identifiers: {
-    name: string;
-    slug: string;
-  };
-  ronin: {
-    createdAt: Date;
-    updatedAt: Date;
-  };
-}
-
-export type Model = Omit<RecursiveRequired<PartialModel>, 'identifiers'> & BaseModel;
 
 export type ModelField = RecursiveRequired<PartialModelField>;

--- a/packages/blade-codegen/src/types/model.ts
+++ b/packages/blade-codegen/src/types/model.ts
@@ -16,7 +16,6 @@ interface BaseModel {
     createdAt: Date;
     updatedAt: Date;
   };
-  summary?: string;
 }
 
 export type Model = Omit<RecursiveRequired<PartialModel>, 'identifiers'> & BaseModel;

--- a/packages/blade-codegen/src/types/model.ts
+++ b/packages/blade-codegen/src/types/model.ts
@@ -1,7 +1,0 @@
-import type { ModelField as PartialModelField } from 'blade-compiler';
-
-type RecursiveRequired<T> = {
-  [K in keyof T]-?: T[K] extends object ? RecursiveRequired<T[K]> : T[K];
-};
-
-export type ModelField = RecursiveRequired<PartialModelField>;

--- a/packages/blade-codegen/src/types/query.ts
+++ b/packages/blade-codegen/src/types/query.ts
@@ -1,3 +1,3 @@
-import type { DML_QUERY_TYPES } from 'blade-compiler';
+import type { QueryType as BaseQueryType } from 'blade-compiler';
 
-export type QueryType = (typeof DML_QUERY_TYPES)[number] | 'use';
+export type QueryType = BaseQueryType | 'use';

--- a/packages/blade-codegen/src/utils/types.ts
+++ b/packages/blade-codegen/src/utils/types.ts
@@ -4,10 +4,8 @@ import { identifiers, typeArgumentIdentifiers } from '@/src/constants/identifier
 import { MODEL_TYPE_TO_SYNTAX_KIND_KEYWORD } from '@/src/constants/schema';
 import { convertToPascalCase } from '@/src/utils/slug';
 
-import type { ModelField } from 'blade-compiler';
+import type { ModelField, PopulatedModel } from 'blade-compiler';
 import type { TypeNode } from 'typescript';
-
-import type { Model } from '@/src/types/model';
 
 /**
  * Map a RONIN model field to a TypeScript type node.
@@ -19,7 +17,7 @@ import type { Model } from '@/src/types/model';
  */
 export const mapRoninFieldToTypeNode = (
   field: ModelField,
-  models: Array<Model>,
+  models: Array<PopulatedModel>,
 ): Array<TypeNode> => {
   const propertyUnionTypes = new Array<TypeNode>();
 

--- a/packages/blade-codegen/src/zod.ts
+++ b/packages/blade-codegen/src/zod.ts
@@ -1,8 +1,6 @@
 import { convertToPascalCase } from '@/src/utils/slug';
 
-import type { ModelField } from 'blade-compiler';
-
-import type { Model } from '@/src/types/model';
+import type { ModelField, PopulatedModel } from 'blade-compiler';
 
 type ModelFieldType = Required<ModelField>['type'];
 
@@ -41,7 +39,7 @@ const ${ZOD_FIELD_TYPES.json}: z.ZodType<Json> = z.lazy(() =>
  *
  * @returns A string of the complete `index.ts` file.
  */
-export const generateZodSchema = (models: Array<Model>): string => {
+export const generateZodSchema = (models: Array<PopulatedModel>): string => {
   const lines = new Array<string | null>('import { z } from "zod";\n');
 
   // If no models are provided, an empty export is needed to avoid errors.

--- a/packages/blade-codegen/tests/generators/__snapshots__/model.test.ts.snap
+++ b/packages/blade-codegen/tests/generators/__snapshots__/model.test.ts.snap
@@ -146,9 +146,6 @@ exports[`model a model with nested fields 1`] = `
         set: Syntax.SetQuery;
     };
 }
-/**
- * A user account.
- */
 export type Account = Utils.ResultRecord & {
     name: string;
     nested: {
@@ -156,9 +153,6 @@ export type Account = Utils.ResultRecord & {
         foo: string;
     };
 };
-/**
- * A user account.
- */
 export type Accounts = Array<Account> & {
     moreBefore?: string;
     moreAfter?: string;

--- a/packages/blade-codegen/tests/generators/__snapshots__/model.test.ts.snap
+++ b/packages/blade-codegen/tests/generators/__snapshots__/model.test.ts.snap
@@ -27,34 +27,6 @@ export type Accounts = Array<Account> & {
 "
 `;
 
-exports[`model a model with a summary 1`] = `
-"export interface TriggerOptions {
-    client: {
-        add: Syntax.AddQuery;
-        batch: any;
-        count: any;
-        get: Syntax.GetQuery;
-        remove: Syntax.RemoveQuery;
-        set: Syntax.SetQuery;
-    };
-}
-/**
- * A user account.
- */
-export type Account = Utils.ResultRecord & {
-    email: string;
-    name: string;
-};
-/**
- * A user account.
- */
-export type Accounts = Array<Account> & {
-    moreBefore?: string;
-    moreAfter?: string;
-};
-"
-`;
-
 exports[`model a model with an invalid field type 1`] = `
 "export interface TriggerOptions {
     client: {

--- a/packages/blade-codegen/tests/generators/comment.test.ts
+++ b/packages/blade-codegen/tests/generators/comment.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { generateQueryTypeComment } from '@/src/generators/comment';
-
-import type { Model } from '@/src/types/model';
+import type { PopulatedModel as Model } from 'blade-compiler';
 
 describe('comment', () => {
   describe('add', () => {

--- a/packages/blade-codegen/tests/generators/model.test.ts
+++ b/packages/blade-codegen/tests/generators/model.test.ts
@@ -40,29 +40,6 @@ describe('model', () => {
     expect(typesResultStr).toMatchSnapshot();
   });
 
-  test('a model with a summary', () => {
-    const AccountModel = model({
-      slug: 'account',
-      pluralSlug: 'accounts',
-      fields: {
-        name: string(),
-        email: string({ required: true }),
-      },
-      // @ts-expect-error This property is not native to RONIN models.
-      summary: 'A user account.',
-    });
-
-    // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.
-    // @ts-expect-error Codegen models types differ from the schema model types.
-    const typesResult = generateModelTypes([AccountModel], AccountModel);
-
-    expect(typesResult).toHaveLength(3);
-
-    const typesResultStr = printNodes(typesResult);
-
-    expect(typesResultStr).toMatchSnapshot();
-  });
-
   test('a model with an invalid field type', () => {
     const field = string();
 
@@ -179,8 +156,6 @@ describe('model', () => {
         'nested.foo': string(),
         'nested.bar': number(),
       },
-      // @ts-expect-error This property is not native to RONIN models.
-      summary: 'A user account.',
     });
 
     // TODO(@nurodev): Refactor the `Model` type to be more based on current schema models.

--- a/packages/blade-codegen/tests/generators/namespaces.test.ts
+++ b/packages/blade-codegen/tests/generators/namespaces.test.ts
@@ -13,7 +13,7 @@ import {
 import { generateNamespaces } from '@/src/generators/namespaces';
 import { printNodes } from '@/src/utils/print';
 
-import type { Model } from '@/src/types/model';
+import type { PopulatedModel as Model } from 'blade-compiler';
 
 describe('namespaces', () => {
   test('with a basic model', () => {

--- a/packages/blade-codegen/tests/generators/syntax.test.ts
+++ b/packages/blade-codegen/tests/generators/syntax.test.ts
@@ -6,7 +6,7 @@ import { generateUsingSyntax, generateWithSyntax } from '@/src/generators/syntax
 import { printNodes } from '@/src/utils/print';
 import { convertToPascalCase } from '@/src/utils/slug';
 
-import type { Model } from '@/src/types/model';
+import type { PopulatedModel as Model } from 'blade-compiler';
 
 describe('syntax', () => {
   describe('using', () => {

--- a/packages/blade-compiler/src/index.ts
+++ b/packages/blade-compiler/src/index.ts
@@ -572,6 +572,7 @@ class Transaction {
 // Expose model types
 export type {
   PublicModel as Model,
+  Model as PopulatedModel,
   ModelField,
   ModelIndex,
   ModelPreset,

--- a/packages/blade/private/shell/index.ts
+++ b/packages/blade/private/shell/index.ts
@@ -67,7 +67,7 @@ if (isApplying) await cmdApply(appToken, values);
 // `blade types` command.
 const isGeneratingTypes = normalizedPositionals.includes('types');
 if (isGeneratingTypes) {
-  await cmdTypes(appToken, values);
+  await cmdTypes(values, positionals);
   process.exit(0);
 }
 


### PR DESCRIPTION
This change ensures that `blade types` works for local models, even if no database exists yet.