### PR TITLE
Ensure working in-memory builds

### DIFF
--- a/packages/blade/tsdown.config.ts
+++ b/packages/blade/tsdown.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
     'react-dom/server.edge',
     'typescript',
   ],
+  noExternal: ['hive', 'hive/remote-storage'],
   treeshake: true,
   define: {
     // Deno does not support `global` and certain dependencies that Blade uses are


### PR DESCRIPTION
This change ensures that in-memory builds are working correctly by bundling the parts of our database engine that we want to bundle explicitly.

The rest of it remains unbundled, since the other imports are `hive/bun-driver` and `hive/disk-storage`, which rely on native modules and therefore can't be bundled.