### PR TITLE
Added remote dependency loading support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
     },
     "packages/blade": {
       "name": "blade",
-      "version": "3.20.0",
+      "version": "3.23.0",
       "bin": {
         "blade": "./dist/private/shell/index.js",
       },
@@ -24,7 +24,6 @@
         "dotenv": "16.5.0",
         "gradient-string": "3.0.0",
         "hive": "2.1.4",
-        "resolve-from": "5.0.0",
         "rolldown": "1.0.0-beta.41",
       },
       "devDependencies": {
@@ -68,7 +67,7 @@
     },
     "packages/blade-auth": {
       "name": "blade-auth",
-      "version": "3.20.0",
+      "version": "3.23.0",
       "devDependencies": {
         "better-auth": "1.3.27",
         "tsdown": "0.15.5",
@@ -77,7 +76,7 @@
     },
     "packages/blade-cli": {
       "name": "blade-cli",
-      "version": "3.20.0",
+      "version": "3.23.0",
       "dependencies": {
         "@dprint/formatter": "0.4.1",
         "@dprint/typescript": "0.93.3",
@@ -107,7 +106,7 @@
     },
     "packages/blade-client": {
       "name": "blade-client",
-      "version": "3.20.0",
+      "version": "3.23.0",
       "dependencies": {
         "hive": "2.1.4",
       },
@@ -122,7 +121,7 @@
     },
     "packages/blade-codegen": {
       "name": "blade-codegen",
-      "version": "3.20.0",
+      "version": "3.23.0",
       "dependencies": {
         "typescript": "5.7.3",
       },
@@ -136,7 +135,7 @@
     },
     "packages/blade-compiler": {
       "name": "blade-compiler",
-      "version": "3.20.0",
+      "version": "3.23.0",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.1.14",
@@ -148,7 +147,7 @@
     },
     "packages/blade-syntax": {
       "name": "blade-syntax",
-      "version": "3.20.0",
+      "version": "3.23.0",
       "devDependencies": {
         "@biomejs/biome": "1.9.4",
         "@types/bun": "1.2.4",
@@ -160,7 +159,7 @@
     },
     "packages/create-blade": {
       "name": "create-blade",
-      "version": "3.20.0",
+      "version": "3.23.0",
       "bin": {
         "create-blade": "./dist/index.js",
       },

--- a/packages/blade/package.json
+++ b/packages/blade/package.json
@@ -65,7 +65,6 @@
     "dotenv": "16.5.0",
     "gradient-string": "3.0.0",
     "hive": "2.1.4",
-    "resolve-from": "5.0.0",
     "rolldown": "1.0.0-beta.41"
   },
   "devDependencies": {

--- a/packages/blade/public/server/build.ts
+++ b/packages/blade/public/server/build.ts
@@ -1,5 +1,4 @@
 import path from 'node:path';
-import resolveFrom from 'resolve-from';
 import { aliasPlugin } from 'rolldown/experimental';
 
 import { nodePath, sourceDirPath } from '@/private/shell/constants';
@@ -160,14 +159,10 @@ export const build = async (
               return `unpkg:${resolvedPath}`;
             }
 
+            // If it's a relative import not from unpkg, let other plugins handle it
             if (id.startsWith('.')) return undefined;
 
-            try {
-              const resolved = resolveFrom(nodePath, id);
-              if (resolved) return resolved;
-            } catch {
-              return `unpkg:${id}`;
-            }
+            return `unpkg:${id}`;
           },
         },
         load: {


### PR DESCRIPTION
This PR updates the memory dependency loader used by `blade` to allow for fetching dependencies direct from a CDN, in this case unpkg.com, rather than needing to install them locally.