### PR TITLE
Ensure correct language styles

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Ensure these .ts entrypoints count as TypeScript (override shebang heuristic)
+packages/create-blade/src/index.ts linguist-language=TypeScript
+packages/blade/private/shell/index.ts linguist-language=TypeScript


### PR DESCRIPTION
This change ensures that the repo correctly shows all files as TypeScript in the repo sidebar:

<img width="684" height="210" alt="CleanShot 2025-10-15 at 16 36 22@2x" src="https://github.com/user-attachments/assets/e404f11d-928c-4b09-ac5a-d37f622941d7" />
