### PR TITLE
Avoid unnecessary paints during client transition

### DIFF
--- a/packages/blade/private/client/components/history.tsx
+++ b/packages/blade/private/client/components/history.tsx
@@ -51,7 +51,7 @@ const HistoryContent: FunctionComponent<HistoryContentProps> = ({ children }) =>
   // multiple because the updates within it are mutually exclusive.
   useLayoutEffect(() => {
     // Don't proceed if the page is loaded fresh.
-    if (!lastPopulatedPathname) return;
+    if (!lastPopulatedPathname.current) return;
 
     // Don't proceed if the address bar should not be updated.
     if (!universalContext.addressBarInSync) return;


### PR DESCRIPTION
This change ensures that, if you are linked to a page with a hash in the URL (meaning the link contains the hash), the next paint will be at that exact anchor element that you were linked to, whereas, at the moment, the page first renders and then scrolls to the anchor.