### PR TITLE
Document trigger errors

### DIFF
--- a/docs/pages/auth.mdx
+++ b/docs/pages/auth.mdx
@@ -203,7 +203,7 @@ const account = use.account.with({ emailVerificationToken });
 )}
 ```
 
-## Utility functions
+## Utility Functions
 
 Blade also re-exports a few helpful utility functions for authentication:
 

--- a/docs/pages/models/triggers.mdx
+++ b/docs/pages/models/triggers.mdx
@@ -362,3 +362,35 @@ Additionally, sink queries receive additional properties within the `options` ob
 allow for identifying the original query more easily. A `model` property contains the
 slug of the model that was targeted, and a `database` property contains the slug of the
 database that was targeted.
+
+## Trigger Errors
+
+To make creating triggers as easy as possible, Blade provides a list of default errors
+that can be thrown from triggers and used on the client-side to assert specific behavior.
+
+```ts
+import {
+  TriggerError,
+  InvalidFieldsError,
+  EmptyFieldsError,
+  ExtraneousFieldsError,
+  RecordExistsError,
+  RecordNotFoundError,
+  TooManyRequestsError,
+  InvalidPermissionsError,
+  AddNotAllowedError,
+  SetNotAllowedError,
+  RemoveNotAllowedError,
+  MultipleWithInstructionsError,
+} from 'blade/server';
+```
+
+On the client, you can then use the following pattern to match against those errors:
+
+```ts
+import { InvalidFieldsError } from 'blade/server';
+
+if (err instanceof InvalidFieldsError) {
+  // Run logic
+}
+```


### PR DESCRIPTION
This change documents all the native errors exposed for triggers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a "Trigger Errors" section to triggers docs with exported error classes and an example of client-side instanceof checks.
> 
> - **Docs — Triggers**:
>   - Add **Trigger Errors** section:
>     - List exported errors from `blade/server` (e.g., `InvalidFieldsError`, `RecordNotFoundError`, `TooManyRequestsError`, etc.).
>     - Provide client-side `instanceof` pattern to handle specific trigger errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b92bb3b04abd2b9fe1e649141f63f4c393727e8b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->