### PR TITLE
Expose SQL statement errors to client

### DIFF
--- a/docs/pages/models/triggers.mdx
+++ b/docs/pages/models/triggers.mdx
@@ -382,6 +382,9 @@ import {
   SetNotAllowedError,
   RemoveNotAllowedError,
   MultipleWithInstructionsError,
+
+  ClientError,
+  CompilerError
 } from 'blade/server';
 ```
 

--- a/packages/blade/public/universal/errors.ts
+++ b/packages/blade/public/universal/errors.ts
@@ -11,4 +11,6 @@ export {
   SetNotAllowedError,
   RemoveNotAllowedError,
   MultipleWithInstructionsError,
+  ClientError,
+  CompilerError,
 } from 'blade-client/utils';


### PR DESCRIPTION
This change makes it possible for the client to match against SQL statement errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 6074cfd85a299b68ab45f8883151df199fd085d6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->