### PR TITLE
Support external links

### DIFF
--- a/docs/pages/components.mdx
+++ b/docs/pages/components.mdx
@@ -8,9 +8,12 @@ import { ParamField } from '@/components/param-field.client';
 
 ## `Link`
 
-When writing Blade apps, [anchor elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a) should only be used for linking to external URLs.
+Used to render a clickable link that forwards the user to a different page.
 
-For linking to URLs within the same application, use the native `Link` component instead:
+For maximum ease of use, the component also supports hash links (such as `#test`) and
+external links (starting with a protocol such as `https://` or `http://`), however, in
+those cases, a simple [anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a)
+with no event handlers will be rendered.
 
 ```tsx
 import { Link } from 'blade/components';

--- a/packages/blade/private/client/components/link.tsx
+++ b/packages/blade/private/client/components/link.tsx
@@ -116,8 +116,8 @@ const Link: FunctionComponent<LinkProps> = ({
   // Of course there is no reason to use the `Link` component in the first place in those
   // cases (apps can just use the anchor element directly), but we still want to support
   // it for ease of use, such that apps don't need to themselves switch between different
-  // behaviors based on what the `href` looks like. This is especially useful with MDX,
-  // since all links can then just use the `Link` component.
+  // behaviors based on what `href` looks like. This is especially useful with MDX, since
+  // all links can then just use the `Link` component.
   if (href.startsWith('#') || isExternal) {
     eventHandlers = undefined;
   }


### PR DESCRIPTION
Similar to https://github.com/ronin-co/blade/pull/603, this ensures that the `Link` component supports external links, for ensuring maximum ease of use and the cleanest application codebase syntax.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances `Link` to treat external and hash-only URLs as browser-handled (no prefetch/handlers), opening externals in a new tab with `noreferrer`, and updates docs accordingly.
> 
> - **Client** (`packages/blade/private/client/components/link.tsx`):
>   - Handle external (`http(s)://`) and hash-only (`#...`) `href`s by disabling Blade link event handlers/prefetch.
>   - Add `target="_blank"` and `rel="noreferrer"` for external links.
>   - Simplify prefetch logic; event handlers apply only to internal links.
> - **Docs** (`docs/pages/components.mdx`):
>   - Revise `Link` section to describe internal navigation, support for hash/external links, and rendering as plain anchor when external/hash.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 834d84d8e78ac0bdc93d10a2bded3632182031ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->