### PR TITLE
Add `Image` component example

### DIFF
--- a/docs/pages/components.mdx
+++ b/docs/pages/components.mdx
@@ -289,6 +289,12 @@ Building a fast web application that instantly provides joy to its users wheneve
 accessed (rather than introducing delays) typically requires paying attention to a number
 of different components.
 
+```tsx
+import { Image } from 'blade/components';
+
+<Image src="/juri.png" width={100} height={100} alt="A picture of Juri" />
+```
+
 Blade aims to automatically provide you with the optimizations you need to guarantee the
 fastest experience possible, additionally letting you fine-tune those improvements where necessary.
 


### PR DESCRIPTION
The image component documentation was missing an example code snippet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a short import-and-usage code snippet for the `Image` component in `docs/pages/components.mdx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53130b172c8494bfd7b4a46c176e03559d336d63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->