### PR TITLE
Ensure correct outgoing headers

### DIFF
--- a/packages/blade/private/server/utils/index.ts
+++ b/packages/blade/private/server/utils/index.ts
@@ -77,7 +77,13 @@ export class ResponseStream extends SSEStreamingApi {
    */
   writeChunk(type: 'update' | 'update-bundle', response: Response) {
     // Migrate the headers to the final response.
-    response.headers.forEach((value, key) => this.response.headers.append(key, value));
+    response.headers.forEach((value, key) => {
+      if (key === 'set-cookie') {
+        this.response.headers.append(key, value);
+      } else {
+        this.response.headers.set(key, value);
+      }
+    });
 
     // Inform any outside watchers that the response now has headers and can be returned,
     // such that the response is returned to the client even before the first body chunk


### PR DESCRIPTION
This change further improves https://github.com/ronin-co/blade/pull/608 by ensuring that no headers are duplicated that don't need to be duplicated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjust header propagation in `ResponseStream.writeChunk` to overwrite non-cookie headers while preserving multiple `set-cookie` values.
> 
> - **Server utils (`ResponseStream`)**:
>   - Update `writeChunk` header merge logic: use `headers.set` for all headers except `set-cookie`, which still uses `headers.append` to allow multiple cookies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 19c13dce16943d42f85ac63b6ca36a40269f2912. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->