### PR TITLE
Use a single connection for writes

### DIFF
--- a/packages/blade-client/src/queries.ts
+++ b/packages/blade-client/src/queries.ts
@@ -52,7 +52,7 @@ const defaultDatabaseCaller: QueryHandlerOptions['databaseCaller'] = async (
   options,
 ) => {
   const { token, database, stream } = options;
-  const key = `${token || 'local'}${stream ? `-${stream}` : ''}`;
+  const key = `${token || 'local'}${stream ? '-stream' : ''}`;
 
   if (!clients[key]) {
     // If a token is available, initiate a connection to the remote storage.


### PR DESCRIPTION
This change ensures that all write queries are sent through a single database connection. In the near future, we will likely start parallelizing again, once the database engine supports it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use a single Hive client per token in stream mode by changing the client cache key to append "-stream" instead of a per-stream identifier.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e297f531399c064f76768b6f3674760306967cad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->