### PR TITLE
Add remote dependency fetching

### DIFF
--- a/packages/blade/public/server/build.ts
+++ b/packages/blade/public/server/build.ts
@@ -87,7 +87,7 @@ const fetchFromCDN = async (
  * These are resolved from local node_modules via aliases.
  */
 const EXCLUDED_DEPENDENCIES = new Set([
-  // React server context's can conflict if multiple versions are loaded
+  // React server contexts can conflict if multiple versions are loaded
   'react',
   'react-dom',
   'scheduler',


### PR DESCRIPTION
This PR updates the memory dependency loader plugin for the Blade pragmatic build API (`blade/server/build`) to make it so dependencies are fetched from `unpkg.com` instead of using local `node_modules` files.

However, there is a few minor known issues to make note of but not blocking worthy:
 - A handful of dependencies that require a local install, including `react`, `react-dom` & `scheduler`.
 - Some dependencies are incorrectly mapping their paths to an `unpkg.com` path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Memory Dependency Loader to resolve and fetch dependencies from unpkg with caching, URL-based module typing, and React-family exclusions.
> 
> - **Build (`packages/blade/public/server/build.ts`)**:
>   - **Memory Dependency Loader**:
>     - Resolves bare and relative imports to `unpkg` as `cdn:` URLs; adds loader to fetch content, cache results, and detect module type from URL.
>     - Supports relative resolution for CDN-imported modules; ignores hashed internal chunks; keeps `blade/*` and excluded deps resolved via `node_modules` with fallback.
>     - Excludes `react`, `react-dom`, `scheduler` from CDN resolution.
>   - **Utilities**:
>     - Introduces `DEPENDENCY_CACHE`, `resolveImportPath`, `detectModuleType`, `fetchFromCDN`, and `isExcludedDependency` helpers.
>   - **Filters**:
>     - Expands resolver filter to include relative paths (`./`, `../`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46d17ba70ea4be2f8dc4f26e854a810eaf258a2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->