### PR TITLE
Correctly load triggers

### DIFF
--- a/packages/blade/private/server/types/index.ts
+++ b/packages/blade/private/server/types/index.ts
@@ -98,7 +98,7 @@ export type Triggers<
 
 export type TriggersList<TSchema = unknown> = Record<
   string,
-  Triggers<QueryType, TSchema>
+  { default: Triggers<QueryType, TSchema> }
 >;
 export type PageList = Record<string, TreeItem | 'DIRECTORY'>;
 export type ModelList = { 'index.ts'?: Record<string, Model> };

--- a/packages/blade/private/server/utils/data.ts
+++ b/packages/blade/private/server/utils/data.ts
@@ -115,7 +115,7 @@ export const getClientConfig = (
   };
 
   const list = Object.entries(triggers || {}).map(
-    ([fileName, triggerList]): [string, NewTriggers] => {
+    ([fileName, { default: triggerList }]): [string, NewTriggers] => {
       // For every trigger, update the existing options argument to provide additional
       // options that are specific to BLADE.
       const extendedTriggerEntries = Object.entries(triggerList).map(


### PR DESCRIPTION
This change ensures that triggers defined for an application are loaded correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch trigger modules to use a default export and update server-side loading to read `default` when building trigger maps.
> 
> - **Server Types**:
>   - Update `TriggersList` to expect `{ default: Triggers<...> }` per module instead of raw `Triggers`.
> - **Server Utils** (`packages/blade/private/server/utils/data.ts`):
>   - Adjust trigger loading to destructure `{ default: triggerList }` from `triggers` entries when extending options and constructing `finalTriggers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9630559363829b0177353543e6bd2629cb1570c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->