### PR TITLE
Support in-memory `styles.css` for Tailwind

### DIFF
--- a/packages/blade/private/shell/loaders.ts
+++ b/packages/blade/private/shell/loaders.ts
@@ -290,6 +290,7 @@ export const getProviderLoader = (
 
 export const getTailwindLoader = (
   environment: 'development' | 'production',
+  virtualFiles?: Array<VirtualFileItem>,
 ): RolldownPlugin => {
   let compiler: Awaited<ReturnType<typeof compileTailwind>>;
   let candidates: Array<string> = [];
@@ -304,7 +305,10 @@ export const getTailwindLoader = (
       // Always reading the file and handling the error if the file doesn't exist is
       // faster than first checking if the file exists.
       try {
-        input = await readFile(styleInputFile, 'utf8');
+        const virtualFile = virtualFiles?.find((item) => item.path === '/styles.css');
+        input = virtualFile
+          ? virtualFile.content
+          : await readFile(styleInputFile, 'utf8');
       } catch (err) {
         if ((err as { code: string }).code !== 'ENOENT') throw err;
       }

--- a/packages/blade/private/shell/utils/build.ts
+++ b/packages/blade/private/shell/utils/build.ts
@@ -136,7 +136,7 @@ export const composeBuildContext = async (
       getMdxLoader(environment),
       getReactAriaLoader(),
       getClientReferenceLoader(),
-      getTailwindLoader(environment),
+      getTailwindLoader(environment, options?.virtualFiles),
       getProviderLoader(environment, provider),
       ...(options?.plugins || []),
     ],


### PR DESCRIPTION
This change makes it possible to provide `styles.css` for in-memory Tailwind builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable Tailwind to compile from an in-memory `/styles.css` by passing `virtualFiles` through the build and reading it in the Tailwind loader.
> 
> - **Tailwind Loader (`loaders.ts`)**:
>   - Accepts optional `virtualFiles` parameter.
>   - Reads `/styles.css` from `virtualFiles` when provided; falls back to filesystem.
> - **Build Pipeline (`utils/build.ts`)**:
>   - Forwards `options.virtualFiles` to `getTailwindLoader`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f672fe8b7d5965dc29c159d789127d4ca3768cbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->