### PR TITLE
Upgrade package on docs and templates

### DIFF
--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -10,7 +10,7 @@
         "@radix-ui/react-slot": "1.2.3",
         "@radix-ui/react-tooltip": "1.2.7",
         "@tabler/icons-react": "3.34.0",
-        "blade": "3.29.0",
+        "blade": "3.29.6",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "lucide-react": "0.513.0",
@@ -271,7 +271,7 @@
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
 
-    "blade": ["blade@3.29.0", "", { "dependencies": { "@dprint/typescript": "0.95.11", "@inquirer/prompts": "7.8.6", "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.16", "@tailwindcss/oxide": "4.1.16", "dotenv": "16.5.0", "gradient-string": "3.0.0", "hive": "2.1.13", "resolve-from": "5.0.0", "rolldown": "1.0.0-beta.44" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-kvvMzEzYjMpxEWgjYVYm3k9WTwybjd5IGzYEOR2XE6KmMBoGaaKAyWk4PDpT8mTgDHU+oAauzqonEf/SzlXRBA=="],
+    "blade": ["blade@3.29.6", "", { "dependencies": { "@dprint/typescript": "0.95.11", "@inquirer/prompts": "7.8.6", "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.16", "@tailwindcss/oxide": "4.1.16", "dotenv": "16.5.0", "gradient-string": "3.0.0", "hive": "2.1.13", "resolve-from": "5.0.0", "rolldown": "1.0.0-beta.44" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-crbXZCRhsVR5DUBPoHbfuW1/+PHSnEwb9DuhWOUZRcXnQaxc5t/hkomZC+rJg4/ld+dOQC2MqbzAriS6zg9Lyw=="],
 
     "bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -17,7 +17,7 @@
     "@radix-ui/react-separator": "1.1.7",
     "@radix-ui/react-slot": "1.2.3",
     "@radix-ui/react-tooltip": "1.2.7",
-    "blade": "3.29.0",
+    "blade": "3.29.6",
     "@tabler/icons-react": "3.34.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/packages/create-blade/templates/advanced/bun.lock
+++ b/packages/create-blade/templates/advanced/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "advanced-example",
       "dependencies": {
-        "blade": "3.29.0",
+        "blade": "3.29.6",
         "react": "19.2.0",
         "react-dom": "19.2.0",
       },
@@ -152,7 +152,7 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "blade": ["blade@3.29.0", "", { "dependencies": { "@dprint/typescript": "0.95.11", "@inquirer/prompts": "7.8.6", "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.16", "@tailwindcss/oxide": "4.1.16", "dotenv": "16.5.0", "gradient-string": "3.0.0", "hive": "2.1.13", "resolve-from": "5.0.0", "rolldown": "1.0.0-beta.44" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-kvvMzEzYjMpxEWgjYVYm3k9WTwybjd5IGzYEOR2XE6KmMBoGaaKAyWk4PDpT8mTgDHU+oAauzqonEf/SzlXRBA=="],
+    "blade": ["blade@3.29.6", "", { "dependencies": { "@dprint/typescript": "0.95.11", "@inquirer/prompts": "7.8.6", "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.16", "@tailwindcss/oxide": "4.1.16", "dotenv": "16.5.0", "gradient-string": "3.0.0", "hive": "2.1.13", "resolve-from": "5.0.0", "rolldown": "1.0.0-beta.44" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-crbXZCRhsVR5DUBPoHbfuW1/+PHSnEwb9DuhWOUZRcXnQaxc5t/hkomZC+rJg4/ld+dOQC2MqbzAriS6zg9Lyw=="],
 
     "bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
 

--- a/packages/create-blade/templates/advanced/package.json
+++ b/packages/create-blade/templates/advanced/package.json
@@ -10,7 +10,7 @@
   },
   "author": "ronin",
   "dependencies": {
-    "blade": "3.29.0",
+    "blade": "3.29.6",
     "react": "19.2.0",
     "react-dom": "19.2.0"
   },

--- a/packages/create-blade/templates/basic/bun.lock
+++ b/packages/create-blade/templates/basic/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "basic-example",
       "dependencies": {
-        "blade": "3.29.0",
+        "blade": "3.29.6",
         "react": "19.2.0",
         "react-dom": "19.2.0",
       },
@@ -152,7 +152,7 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
-    "blade": ["blade@3.29.0", "", { "dependencies": { "@dprint/typescript": "0.95.11", "@inquirer/prompts": "7.8.6", "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.16", "@tailwindcss/oxide": "4.1.16", "dotenv": "16.5.0", "gradient-string": "3.0.0", "hive": "2.1.13", "resolve-from": "5.0.0", "rolldown": "1.0.0-beta.44" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-kvvMzEzYjMpxEWgjYVYm3k9WTwybjd5IGzYEOR2XE6KmMBoGaaKAyWk4PDpT8mTgDHU+oAauzqonEf/SzlXRBA=="],
+    "blade": ["blade@3.29.6", "", { "dependencies": { "@dprint/typescript": "0.95.11", "@inquirer/prompts": "7.8.6", "@stefanprobst/rehype-extract-toc": "3.0.0", "@tailwindcss/node": "4.1.16", "@tailwindcss/oxide": "4.1.16", "dotenv": "16.5.0", "gradient-string": "3.0.0", "hive": "2.1.13", "resolve-from": "5.0.0", "rolldown": "1.0.0-beta.44" }, "bin": { "blade": "dist/private/shell/index.js" } }, "sha512-crbXZCRhsVR5DUBPoHbfuW1/+PHSnEwb9DuhWOUZRcXnQaxc5t/hkomZC+rJg4/ld+dOQC2MqbzAriS6zg9Lyw=="],
 
     "bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
 

--- a/packages/create-blade/templates/basic/package.json
+++ b/packages/create-blade/templates/basic/package.json
@@ -10,7 +10,7 @@
   },
   "author": "ronin",
   "dependencies": {
-    "blade": "3.29.0",
+    "blade": "3.29.6",
     "react": "19.2.0",
     "react-dom": "19.2.0"
   },


### PR DESCRIPTION
This change adds the latest version of the `blade` packages to the docs and all templates!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Bumps `blade` from 3.29.0 to 3.29.6 across docs and both create-blade templates, updating lockfiles accordingly.
> 
> - **Dependencies**:
>   - **Upgrade `blade` to `3.29.6`**:
>     - `docs/package.json` and `docs/bun.lock`
>     - `packages/create-blade/templates/basic/package.json` and `bun.lock`
>     - `packages/create-blade/templates/advanced/package.json` and `bun.lock`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5b30d143f02d356791887a028618103ce466bf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->