### PR TITLE
Document that triggers are kebab-cased

### DIFF
--- a/docs/pages/models/triggers.mdx
+++ b/docs/pages/models/triggers.mdx
@@ -25,8 +25,12 @@ at the root of your project. Within it, create a file with the slug of the
 
 For example, if the slug of your model is `chatMessage`, you could add the file below.
 
-While the slugs of [models](/models) are [camel-case](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case) (that's how properties are defined
-in JavaScript), the file names of triggers are [kebab-case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) (that's the most common file naming convention in the JavaScript ecosystem and prevents issues on [case-insensitive](https://en.wikipedia.org/wiki/Case_sensitivity) file systems).
+While the slugs of [models](/models) are
+[camel-case](https://developer.mozilla.org/en-US/docs/Glossary/Camel_case) (that's how
+properties are defined in JavaScript), the file names of triggers
+are [kebab-case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) (that's
+the most common file naming convention in the JavaScript ecosystem and prevents issues
+on [case-insensitive](https://en.wikipedia.org/wiki/Case_sensitivity) file systems).
 
 ```ts
 // triggers/chat-message.ts


### PR DESCRIPTION
We should, in the future, consider supporting any kind of casing for all files. Until we do that, we need to document which casing is required, as mentioned [here](https://discord.com/channels/1099977902629589095/1426862609092575302/1436266108243021855).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit e5a391c73712f0534e8c264e40173a233bfeb0f2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->